### PR TITLE
Spain and Iraq map changes

### DIFF
--- a/history/states/165-Catalonia.txt
+++ b/history/states/165-Catalonia.txt
@@ -23,9 +23,10 @@ state={
 			arms_factory = 3
 			industrial_complex = 6
 			#air_base = 2
-			#9764 = {
-			#	naval_base = 4
-			#}
+			9764 = {
+				coastal_bunker = 15
+				naval_base = 4
+			}
 		}
 		add_core_of = SPR
 	}

--- a/history/states/290-Spanish Africa.txt
+++ b/history/states/290-Spanish Africa.txt
@@ -26,12 +26,12 @@ state={
 		buildings = {
 			infrastructure = 3
 			air_base = 3
-			12100 = {
-				naval_base = 3
-			}
-			9945 = {
-				naval_base = 3
-			}
+			#12100 = {
+			#	naval_base = 3
+			#}
+			#9945 = {
+			#	naval_base = 3
+			#}
 		}
 	}
 

--- a/history/states/291-Iraq.txt
+++ b/history/states/291-Iraq.txt
@@ -11,7 +11,9 @@ state={
 	}
 
 	history={
-		owner = IRQ
+		owner = ENG
+		add_core_of = IRQ
+		add_claim_by = KUR
 		victory_points = {
 			2097 10
 		}
@@ -31,8 +33,6 @@ state={
 				naval_base = 1
 			}
 		}
-		add_core_of = IRQ
-		add_claim_by = KUR
 	}
 
 	provinces={

--- a/history/states/297-Belgian Africa.txt
+++ b/history/states/297-Belgian Africa.txt
@@ -15,12 +15,12 @@ state=
 		}
 		buildings = {
 			infrastructure = 2
-			1903 = {
-				naval_base = 1
-			}
-			8244 = {
-				naval_base = 1
-			}
+			#1903 = {
+			#	naval_base = 1
+			#}
+			#8244 = {
+			#	naval_base = 1
+			#}
 		}
 	}
 	provinces=

--- a/history/states/675-Al Hajara.txt
+++ b/history/states/675-Al Hajara.txt
@@ -6,14 +6,14 @@ state={
 	state_category = wasteland
 
 	history={
-		owner = IRQ
+		owner = ENG
+		add_core_of = IRQ
 		victory_points = {
 			12413 1 
 		}
 		buildings = {
 			infrastructure = 4
 		}
-		add_core_of = IRQ
 	}
 	
 	provinces={

--- a/history/states/676-Mosul.txt
+++ b/history/states/676-Mosul.txt
@@ -11,7 +11,9 @@ state={
 
 
 	history={
-		owner = IRQ
+		owner = ENG
+		add_core_of = IRQ
+		add_core_of = KUR
 		buildings = {
 			infrastructure = 4
 		}
@@ -24,8 +26,6 @@ state={
 		victory_points = {
 			6826 1
 		}
-		add_core_of = IRQ
-		add_core_of = KUR
 	}
 	
 	provinces={

--- a/history/states/699-Rio de Oro.txt
+++ b/history/states/699-Rio de Oro.txt
@@ -10,9 +10,9 @@ state={
 		add_core_of = WES
 		buildings = {
 			infrastructure = 1
-			8038 = {
-				naval_base = 1
-			}
+			#8038 = {
+			#	naval_base = 1
+			#}
 		}
 		victory_points = {
 			8038 1

--- a/history/states/783-Sidi Ifni.txt
+++ b/history/states/783-Sidi Ifni.txt
@@ -15,9 +15,9 @@ state={
 		add_core_of = MOR
 		buildings = {
 			infrastructure = 1
-			12857 = {
-				naval_base = 1
-			}
+			#12857 = {
+			#	naval_base = 1
+			#}
 		}
 	}
 

--- a/map/adjacencies.csv
+++ b/map/adjacencies.csv
@@ -297,7 +297,6 @@ From;To;Type;Through;start_x;start_y;stop_x;stop_y;adjacency_rule_name;Comment
 3873;8845;impassable;-1;2744;1328;2744;1328;;Spanish;Med;Coast;;
 6966;8845;impassable;-1;2744;1328;2744;1328;;Spanish;Med;Coast;;
 6812;8845;impassable;-1;2744;1328;2744;1328;;Spanish;Med;Coast;;
-9764;8845;impassable;-1;2744;1328;2744;1328;;Spanish;Med;Coast;Barcelona;
 854;8845;impassable;-1;2744;1328;2744;1328;;Spanish;Med;Coast;;
 854;5505;impassable;-1;2744;1328;2744;1328;;Spanish;Med;Coast;;
 6927;5505;impassable;-1;2744;1328;2744;1328;;Spanish;Med;Coast;;


### PR DESCRIPTION
Iraq annexed to England at start

Spain states adjusted: Spain to have 2 provinces with working ports (axis can anchor and not get fucked by impassible. 1 in the Med, 1 in the Atlantic.

- removed ports on African colonies
- Barcelona port brought back (level 15 coastal fort)
- impassible terrain removed.

This is to remove the issues we have had in the past about axis navies getting stuck in Spanish ports and unable to move. 