### PR TITLE
Mod industry balance Part 1

### DIFF
--- a/common/characters/ROM.txt
+++ b/common/characters/ROM.txt
@@ -236,27 +236,6 @@ characters={
 			id=-1
 		}
 	}
-	ROM_gheorge_potopeanu={
-		advisor={
-			slot = political_advisor
-			idea_token = ROM_gheorge_potopeanu
-			allowed  = {
-					original_tag  = ROM
-				}
-				available  = {
-					has_government  = fascism 
-				}
-				traits  = {
-					financial_expert 
-				}
-		}
-		name="ROM_gheorge_potopeanu"
-		portraits={
-			army={
-				small="GFX_idea_advisor_generic_24"
-			}
-		}
-	}
 	ROM_gheorghe_potopeanu={
 		advisor={
 			slot = theorist

--- a/common/decisions/_generic_decisions.txt
+++ b/common/decisions/_generic_decisions.txt
@@ -1767,7 +1767,22 @@ war_measures = {
 			}
         }
     }
-
+	
+	war_bonds_cancel = {
+		icon = generic_industry
+		available = {
+			has_war = yes
+		}
+		visible = {
+			has_decision = war_bonds
+		}
+		fire_only_once = no
+		cost = 0
+		complete_effect = {
+			remove_decision = war_bonds
+		}
+	}
+	
     war_bonds = {
 
     	icon = generic_industry
@@ -1811,14 +1826,15 @@ war_measures = {
 
         fire_only_once = no
 
-		days_remove = 180
+		days_remove = -1
 
-		cost = GER_war_bonds_var?50
+		cost = 0  #GER_war_bonds_var?50
 
 		modifier = {
+			political_power_gain = -0.25
 			consumer_goods_factor = -0.02
 			industrial_capacity_factory = 0.1
-				industrial_capacity_dockyard = 0.1
+			industrial_capacity_dockyard = 0.1
 		}
 
 		ai_will_do = {
@@ -1834,65 +1850,65 @@ war_measures = {
 		}
 
 		complete_effect = {
-			if = {
-				limit = {
-					NOT = {
-						check_variable = {
-							var = GER_war_bonds_var
-							value = 100
-							compare = greater_than_or_equals
-						}
-					}
-				}
-				set_variable = {
-					var = GER_war_bonds_var
-					value = 50
-				}
-			}
-			add_to_variable = {
-				var = GER_war_bonds_var
-				value = 25
-			}
-			if = {
-				limit = {
-					check_variable = {
-						var = GER_war_bonds_var
-						value = 100
-						compare = greater_than_or_equals
-					}
-					NOT = {
-						check_variable = {
-							var = GER_war_bonds_war_support_var
-							value = 5
-							compare = greater_than_or_equals
-						}
-					}
-				}
-				set_variable = {
-					var = GER_war_bonds_war_support_var
-					value = -5
-				}
-				add_war_support = GER_war_bonds_war_support_var
-			}
-			if = {
-				limit = {
-					check_variable = {
-						var = GER_war_bonds_var
-						value = 100
-						compare = greater_than_or_equals
-					}
-					check_variable = {
-						var = GER_war_bonds_war_support_var
-						value = 5
-						compare = greater_than_or_equals
-					}
-				}
-				add_to_variable = {
-					var = GER_war_bonds_war_support_var
-					value = -2.5
-				}
-				add_war_support = GER_war_bonds_war_support_var
-			}
+		#	if = {
+		#		limit = {
+		#			NOT = {
+		#				check_variable = {
+		#					var = GER_war_bonds_var
+		#					value = 100
+		#					compare = greater_than_or_equals
+		#				}
+		#			}
+		#		}
+		#		set_variable = {
+		#			var = GER_war_bonds_var
+		#			value = 50
+		#		}
+		#	}
+		#	add_to_variable = {
+		#		var = GER_war_bonds_var
+		#		value = 25
+		#	}
+		#	if = {
+		#		limit = {
+		#			check_variable = {
+		#				var = GER_war_bonds_var
+		#				value = 100
+		#				compare = greater_than_or_equals
+		#			}
+		#			NOT = {
+		#				check_variable = {
+		#					var = GER_war_bonds_war_support_var
+		#					value = 5
+		#					compare = greater_than_or_equals
+		#				}
+		#			}
+		#		}
+		#		set_variable = {
+		#			var = GER_war_bonds_war_support_var
+		#			value = -5
+		#		}
+		#		add_war_support = GER_war_bonds_war_support_var
+		#	}
+		#	if = {
+		#		limit = {
+		#			check_variable = {
+		#				var = GER_war_bonds_var
+		#				value = 100
+		#				compare = greater_than_or_equals
+		#			}
+		#			check_variable = {
+		#				var = GER_war_bonds_war_support_var
+		#				value = 5
+		#				compare = greater_than_or_equals
+		#			}
+		#		}
+		#		add_to_variable = {
+		#			var = GER_war_bonds_war_support_var
+		#			value = -2.5
+		#		}
+		#		add_war_support = GER_war_bonds_war_support_var
+		#	}
 		}
     }
 	

--- a/common/ideas/australia.txt
+++ b/common/ideas/australia.txt
@@ -268,9 +268,9 @@ ideas = {
 			picture = generic_goods_red_bonus
 			
 			modifier = {
-				consumer_goods_factor = -0.03
-				industrial_capacity_factory = 0.05
-				industrial_capacity_dockyard = 0.05
+				consumer_goods_factor = -0.01
+				industrial_capacity_factory = 0.075
+				industrial_capacity_dockyard = 0.075
 				stability_factor = 0.05
 			}
 		}
@@ -287,9 +287,30 @@ ideas = {
 			picture = generic_goods_red_bonus
 			
 			modifier = {
-				consumer_goods_factor = -0.05
-				industrial_capacity_factory = 0.1
-				industrial_capacity_dockyard = 0.1
+				consumer_goods_factor = -0.03
+				industrial_capacity_factory = 0.15
+				industrial_capacity_dockyard = 0.15
+				stability_factor = 0.1
+			}
+		}
+		
+		AST_invest_in_victory_3 = {
+			allowed = {
+				always = no
+			}
+			allowed_civil_war = {
+				always = yes
+			}
+
+			removal_cost = -1
+
+			picture = ast_all_in
+			
+			modifier = {
+				consumer_goods_factor = -0.03
+				industrial_capacity_factory = 0.225
+				industrial_capacity_dockyard = 0.225
+				production_speed_arms_factory_factor = 0.1
 				stability_factor = 0.1
 			}
 		}

--- a/common/ideas/britain.txt
+++ b/common/ideas/britain.txt
@@ -1668,11 +1668,11 @@ ideas = {
 			removal_cost = -1
 
 			equipment_bonus = {
-				fighter_equipment = {
-					build_cost_ic = -0.1 instant = yes
+				small_plane_airframe = {
+					build_cost_ic = -0.10 instant = yes
 				}
-				heavy_fighter_equipment = {
-					build_cost_ic = -0.1 instant = yes
+				medium_plane_fighter_airframe = {
+					build_cost_ic = -0.10 instant = yes
 				}
 			}
 			modifier = {

--- a/common/ideas/british_raj.txt
+++ b/common/ideas/british_raj.txt
@@ -301,10 +301,10 @@ ideas = {
 			removal_cost = -1
 
 			modifier = {
-				consumer_goods_factor = 0.03
+				consumer_goods_factor = 0.01
 				production_speed_arms_factory_factor = 0.15
 				production_speed_dockyard_factor = 0.075
-				min_export = -0.075
+				min_export = -0.05
 			}
 		}
 
@@ -410,7 +410,7 @@ ideas = {
 			removal_cost = -1
 
 			modifier = {
-				army_morale_factor = 0.75
+				army_morale_factor = 0.075
 				army_org_factor = 0.05
 			}
 			targeted_modifier = {
@@ -1680,8 +1680,9 @@ ideas = {
 
 			modifier = {
 				stability_factor = 0.1
-				industrial_capacity_dockyard = 0.10
-				consumer_goods_factor = -0.02
+				industrial_capacity_dockyard = 0.12
+				research_speed_factor = 0.10
+				consumer_goods_factor = -0.01
 				conscription_factor = 0.00
 				stability_weekly = 0.001
 				autonomy_gain = 0.4

--- a/common/ideas/bulgaria.txt
+++ b/common/ideas/bulgaria.txt
@@ -652,6 +652,7 @@ ideas = {
 				production_factory_efficiency_gain_factor = 0.1
 				production_factory_max_efficiency_factor = 0.1
 				global_building_slots_factor = 0.2
+				consumer_goods_factor = 0.01
 			}
 		}
 
@@ -668,7 +669,8 @@ ideas = {
 			removal_cost = -1
 
 			modifier = {
-				consumer_goods_factor = -0.05
+				industrial_capacity_factory = 0.1
+				consumer_goods_factor = -0.03
 			}
 		}
 

--- a/common/ideas/canada.txt
+++ b/common/ideas/canada.txt
@@ -283,7 +283,9 @@ ideas = {
 			picture = generic_goods_red_bonus
 			
 			modifier = {
-				consumer_goods_factor = -0.03
+				industrial_capacity_factory = 0.5
+				industrial_capacity_dockyard = 0.5
+				consumer_goods_factor = -0.02
 			}
 		}
 
@@ -302,7 +304,9 @@ ideas = {
 			picture = generic_goods_red_bonus
 			
 			modifier = {
-				consumer_goods_factor = -0.06
+				industrial_capacity_factory = 0.10
+				industrial_capacity_dockyard = 0.10
+				consumer_goods_factor = -0.04
 			}
 		}
 

--- a/common/ideas/etat_francais.txt
+++ b/common/ideas/etat_francais.txt
@@ -202,6 +202,28 @@ ideas = {
 				industrial_capacity_dockyard = 0.15
 			}
 		}
+		
+		EFR_german_industry_support = {
+
+			allowed = {
+				always = no
+			}
+
+			allowed_civil_war = {
+				always = yes
+			}
+
+			removal_cost = -1
+
+			picture = ger_mefo_bills
+
+			modifier = {
+				consumer_goods_factor = -0.02
+				production_speed_buildings_factor = 0.2
+				industrial_capacity_factory = 0.20
+				industrial_capacity_dockyard = 0.05
+			}
+		}
 
 		EFR_war_repairs = {
 			removal_cost = -1

--- a/common/ideas/hungary.txt
+++ b/common/ideas/hungary.txt
@@ -211,7 +211,7 @@ ideas = {
 			picture = generic_goods_red_bonus
 			
 			modifier = {
-			    consumer_goods_factor = -0.05
+			    consumer_goods_factor = -0.04
 				industrial_capacity_factory = 0.10
 				production_factory_max_efficiency_factor = 0.05
 				production_lack_of_resource_penalty_factor = -0.1

--- a/common/ideas/new_zealand.txt
+++ b/common/ideas/new_zealand.txt
@@ -139,7 +139,7 @@ ideas = {
 			picture = generic_goods_red_bonus
 
 			modifier = {
-				consumer_goods_factor = -0.05
+				consumer_goods_factor = -0.04
 			}
 
 		}
@@ -293,7 +293,6 @@ ideas = {
 			picture = generic_pp_unity_bonus
 
 			modifier = {
-				consumer_goods_factor = -0.02
 				production_factory_efficiency_gain_factor = 0.1
 				industrial_capacity_factory = 0.05
 				industrial_capacity_dockyard = 0.05

--- a/common/ideas/romania.txt
+++ b/common/ideas/romania.txt
@@ -167,7 +167,7 @@ ideas = {
 			
 			modifier = {
 				stability_factor = -0.2
-				local_resources_factor = 0.20
+				local_resources_factor = 0.25
 				min_export = 0.2
 				consumer_goods_factor = -0.10
 			}
@@ -966,7 +966,10 @@ ideas = {
 				stability_factor = 0.30
 				political_power_gain = 0.05
 				drift_defence_factor = 0.25
-				conscription_factor = 0.10				
+				conscription_factor = 0.10
+				consumer_goods_factor = 0.02
+				production_speed_industrial_complex_factor = 0.10
+				industrial_capacity_factory = 0.05				
 			}
 		}
 		

--- a/common/ideas/south_africa.txt
+++ b/common/ideas/south_africa.txt
@@ -218,10 +218,9 @@ ideas = {
 			picture = prc_low_popular_support3
 
 			modifier = {
-				industrial_capacity_factory = 0.06
-				industrial_capacity_dockyard = 0.06
-				consumer_goods_factor = -0.015
-				production_speed_buildings_factor = 0.05
+				industrial_capacity_factory = 0.08
+				industrial_capacity_dockyard = 0.08
+				production_speed_buildings_factor = 0.075
 			}
 
 		}
@@ -240,10 +239,10 @@ ideas = {
 			picture = prc_low_popular_support3
 
 			modifier = {
-				industrial_capacity_factory = 0.1
-				industrial_capacity_dockyard = 0.1
-				consumer_goods_factor = -0.025
-				production_speed_buildings_factor = 0.05
+				industrial_capacity_factory = 0.15
+				industrial_capacity_dockyard = 0.15
+				consumer_goods_factor = -0.01
+				production_speed_buildings_factor = 0.075
 			}
 
 		}
@@ -498,7 +497,7 @@ ideas = {
 			picture = generic_goods_red_bonus
 
 			modifier = {
-				consumer_goods_factor = -0.05
+				consumer_goods_factor = -0.04
 			}
 
 		}
@@ -517,9 +516,9 @@ ideas = {
 			picture = generic_goods_red_bonus
 
 			modifier = {
-				consumer_goods_factor = -0.075
-				production_speed_buildings_factor = 0.05
-                local_resources_factor = 0.1
+				consumer_goods_factor = -0.05
+				production_speed_buildings_factor = 0.10
+                local_resources_factor = 0.15
 			}
 
 		}

--- a/common/ideas/spain_nationalist.txt
+++ b/common/ideas/spain_nationalist.txt
@@ -441,7 +441,7 @@ ideas = {
 				industrial_capacity_factory = -0.2
 				industrial_capacity_dockyard = -0.2
 				production_speed_buildings_factor = -0.15
-				consumer_goods_factor = 0.15
+				consumer_goods_factor = 0.10
 			}
 		}
 		
@@ -470,7 +470,7 @@ ideas = {
 				industrial_capacity_factory = -0.15
 				industrial_capacity_dockyard = -0.15
 				production_speed_buildings_factor = -0.1
-				consumer_goods_factor = 0.1
+				consumer_goods_factor = 0.05
 			}
 
 		}
@@ -500,7 +500,6 @@ ideas = {
 				industrial_capacity_factory = -0.1
 				industrial_capacity_dockyard = -0.1
 				production_speed_buildings_factor = -0.1
-				consumer_goods_factor = 0.05
 			}
 		}
 

--- a/common/ideas/usa.txt
+++ b/common/ideas/usa.txt
@@ -179,7 +179,7 @@ ideas = {
 			removal_cost = -1
 
 			modifier = {
-				consumer_goods_factor = 0.05
+				consumer_goods_factor = 0.04
 				political_power_gain = 0.1
 			}
 		}
@@ -197,7 +197,7 @@ ideas = {
 			removal_cost = -1
 
 			modifier = {
-				consumer_goods_factor = 0.10
+				consumer_goods_factor = 0.08
 				political_power_gain = 0.2
 			}
 		}
@@ -222,6 +222,7 @@ ideas = {
 
 			modifier = {
 				political_power_cost = 0.25
+				consumer_goods_factor = 0.01
 				industrial_capacity_factory = 0.025
 				production_factory_max_efficiency_factor = 0.025
 			}

--- a/common/modifiers/00_static_modifiers.txt
+++ b/common/modifiers/00_static_modifiers.txt
@@ -2,154 +2,181 @@
 # Effects are fully scriptable here.
 # These names can NOT be removed or changes, as the code uses them....
 
-weather_rain_light = { # on Region 
-	local_supplies = -0.05
+weather_rain_light = { # on Region
+	air_accidents = 0.1
 	air_detection = -0.1
+	air_mission_efficiency = -0.1
+	local_org_regain = -0.05
 	naval_detection = -0.1
 	naval_hit_chance = -0.05
+	naval_retreat_speed = 0.05
 	naval_speed_factor = -0.05
-	naval_strike = -0.2
-	air_bombing_targetting = -0.15
-	air_accidents = 0.1
-	air_mission_efficiency = -0.1
-	naval_retreat_speed = 0.05					   
-
+	naval_strike = -0.2				   
 	local_org_regain = -0.05
 }
-weather_rain_heavy = { # on Region 
-	local_supplies = -0.10
-	air_detection = -0.2
-	naval_detection = -0.2
-	naval_hit_chance = -0.1
-	naval_speed_factor = -0.1
-	carrier_traffic = -0.2
-	naval_strike = -0.4
+weather_rain_heavy = { # on Region
 	air_accidents = 0.3
 	air_bombing_targetting = -0.5
-					 
-	local_org_regain = -0.2
+	air_detection = -0.2
 	air_mission_efficiency = -0.3
+	carrier_traffic = -0.2
+	local_org_regain = -0.15
+	naval_detection = -0.2
+	naval_hit_chance = -0.1
 	naval_retreat_speed = 0.1
-	positioning = -0.1	   
+	naval_speed_factor = -0.1
+	naval_strike = -0.4
+	org_loss_when_moving = 0.1
+	positioning = -0.1
+	supply_consumption_factor = 0.1
+	supply_factor = -0.05
 }
-weather_snow = { # on Region 
-	local_supplies = -0.15
-	air_detection = -0.5
+weather_snow = { # on Region
+	air_accidents = 0.1
+	air_detection = -0.15
+	air_mission_efficiency = -0.1
 	naval_detection = -0.2
 	naval_hit_chance = -0.05
-	naval_speed_factor = -0.05
-	carrier_traffic = -0.1
-    naval_strike = -0.3
-	air_accidents = 0.1
-	local_org_regain = -0.1
-	air_mission_efficiency = -0.1
 	naval_retreat_speed = 0.05
-	positioning = -0.1					   				   
+	naval_speed_factor = -0.05
+	naval_strike = -0.3
+	org_loss_when_moving = 0.1
+	positioning = -0.1
+	supply_factor = -0.10
+	truck_attrition_factor = 0.3
 }
-weather_blizzard = { # on Region 
-	local_supplies = -0.35
-	air_detection = -0.9
-	naval_detection = -0.3
-	naval_hit_chance = -0.1
-	naval_speed_factor = -0.1
-	carrier_traffic = -0.2
-	naval_strike = -0.4
+weather_blizzard = { # on Region
 	air_accidents = 0.3
 	air_bombing_targetting = -0.7
-	local_org_regain = -0.3
+	air_detection = -0.5
 	air_mission_efficiency = -0.3
+	carrier_traffic = -0.2
+	local_org_regain = -0.1
+	naval_detection = -0.3
+	naval_hit_chance = -0.1
 	naval_retreat_speed = 0.15
-	positioning = -0.2					   				   
-}
-weather_sandstorm = { # on Region 
-	local_supplies = -0.25
-	air_detection = -0.9
-	air_accidents = 0.6
-	naval_strike = -0.9				
-	air_bombing_targetting = -0.8
-	local_org_regain = -0.5
-	air_mission_efficiency = -0.5
-}
-weather_arctic_water = { # on Region 
-	navy_casualty_on_sink = 0.2
-	naval_attrition = 0.1
-	naval_retreat_speed = -0.05
+	naval_speed_factor = -0.1
+	naval_strike = -0.4
+	org_loss_when_moving = 0.25
 	positioning = -0.2
-}									 
-weather_mud = { # on Province
-	local_supplies = -0.3
-	attrition = 0.45
-	army_speed_factor = -0.5
-	army_attack_factor = -0.35
+	supply_consumption_factor = 0.15
+	supply_factor = -0.25
+	truck_attrition_factor = 1.0
+	army_attack_speed_factor = -0.25
+}
+weather_sandstorm = { # on Region
+	air_accidents = 0.6
+	air_bombing_targetting = -1
+	air_detection = -0.9
+	air_mission_efficiency = -0.5
 	local_org_regain = -0.2
-	dig_in_speed_factor = -0.3
+	naval_strike = -0.9
+	org_loss_when_moving = 0.25
+	supply_factor = -0.15
+	truck_attrition_factor = 3.0
 }
 
-weather_extreme_cold = { # on Province
-	local_supplies = -0.25
-	winter_attrition = 0.25
-	dig_in_speed_factor = -0.6
-	local_org_regain = -0.1
+weather_arctic_water = { # on Region
+	naval_attrition = 0.1
+	naval_retreat_speed = -0.05
+	navy_casualty_on_sink = 0.2
+	positioning = -0.2
+}
+
+weather_mud = { # on Province
+	army_attack_factor = -0.4
 	army_speed_factor = -0.5
-	army_attack_factor = -0.5
+	attrition = 0.7
+	org_loss_when_moving = 0.25
+	dig_in_speed_factor = -0.3
+	supply_factor = -0.15
+	truck_attrition_factor = 3.0
+}
+weather_extreme_cold = { # on Province
+	army_attack_factor = -0.4
+	breakthrough_factor = -0.3
 	army_defence_factor = -0.1
+	army_speed_factor = -0.5
+	dig_in_speed_factor = -0.6
+	local_org_regain = -0.05
+	supply_factor = -0.15
+	truck_attrition_factor = 1.0
+	winter_attrition = 0.25
 }
 weather_very_cold = { # on Province
-	local_supplies = -0.2
-	winter_attrition = 0.15
-	dig_in_speed_factor = -0.4
-	army_speed_factor = -0.35
-    local_org_regain = -0.05
-	army_attack_factor = -0.35
+	army_attack_factor = -0.2
+	breakthrough_factor = -0.15
 	army_defence_factor = -0.05
+	army_speed_factor = -0.3
+	dig_in_speed_factor = -0.3
+	winter_attrition = 0.25
 }
 weather_very_hot = { # on Province
-	local_supplies = -0.1
 	heat_attrition = 0.1
-    local_org_regain = -0.05
+	supply_consumption_factor = 0.5
+    army_attack_factor = -0.1
+	local_org_regain = -0.05
+	supply_factor = -0.05
 }
 weather_extreme_hot = { # on Province
-	local_supplies = -0.2
+	army_attack_factor = -0.1
 	heat_attrition = 0.2
-	local_org_regain = -0.1
-    supply_consumption_factor = 0.5
+	supply_consumption_factor = 0.5
     army_attack_factor = -0.1
+	local_org_regain = -0.1
+	supply_consumption_factor = 0.5
+	truck_attrition_factor = 0.1
 }
 weather_ground_snow_medium = { # on Province
-	local_supplies = -0.1
-	army_speed_factor = -0.2
 	army_attack_factor = -0.25
+	army_speed_factor = -0.2
+	army_attack_speed_factor = -0.25
+	breakthrough_factor = -0.15
+	org_loss_when_moving = 0.1
+	supply_factor = -0.20
+	truck_attrition_factor = 0.5
+	dig_in_speed_factor = 0.05
 }
 weather_ground_snow_high = { # on Province
-	local_supplies = -0.2
-	army_speed_factor = -0.3
-	local_org_regain = -0.05
 	army_attack_factor = -0.4
+	army_speed_factor = -0.5
+	army_attack_speed_factor = -0.5
+	breakthrough_factor = -0.3
+	local_org_regain = -0.05
+	org_loss_when_moving = 0.25
+	supply_factor = -0.40
+	truck_attrition_factor = 1.0
+	dig_in_speed_factor = 0.15
 }
+
 flooded = { # on Province
-	army_speed_factor = -0.5
 	army_defence_factor = 0.5
-	dig_in_speed_factor = 0.2
-}
-unplanned_offensive = { # on Province			
 	army_speed_factor = -0.5
-	army_attack_factor = -0.50
-	local_org_regain = -0.15
-	air_mission_efficiency = -0.5
-	#air_bombing_targetting = -0.75
+	dig_in_speed_factor = -0.2
+	org_loss_when_moving = 0.25
+	supply_factor = -0.40
+	truck_attrition_factor = 3.0
+}
+
+unplanned_offensive = { # on Province
+	air_cas_present_factor = -0.75
+	army_attack_factor = -0.9
+	army_speed_factor = -0.75
+	ground_attack_factor = -0.75
+	local_org_regain = -0.5
 }
 
 night = { # On province. Multiplied by amount of darkness.
-	naval_hit_chance = -0.25
-	carrier_traffic = -0.5
-	naval_strike = -0.4
 	air_bombing_targetting = -0.5
-	naval_retreat_speed = 0.1					  
+	carrier_traffic = -1.0
+	naval_hit_chance = -0.25
+	naval_retreat_speed = 0.1
+	air_attack_factor = -0.50
 }
+
 # The following is multiplied by local resistance strength.
 resistance_effect_base = {
 	# todo - spy defense
-					
 }
 
 resistance_effect = {
@@ -164,24 +191,22 @@ compliance_effect_base = {
 	#local_factories = -0.75
 	#local_manpower = -0.75
 	#local_resources = -0.75
-						
 }
 
 compliance_effect = {
 	local_factories = 0.65
 	local_non_core_manpower = 0.18
 	local_resources = 0.60
-					   
 }
 
-# On States
+# On States that are owned by a non-core country
 non_core = {
-
 }
+
 # On States that are controlled by a non-core country
 non_core_controller = {
 	local_building_slots_factor = -0.5
-	
+
 	local_factories = -0.75
 	#local_manpower = -0.75
 	local_resources = -0.65
@@ -310,9 +335,9 @@ free_license = {
 
 # applies when stability > 50%
 stability_good_modifier = {
-	industrial_capacity_factory = 0.1649
-	industrial_capacity_dockyard = 0.1649
-	consumer_goods_factor = -0.045
+	industrial_capacity_factory = 0.205
+	industrial_capacity_dockyard = 0.205
+	consumer_goods_factor = -0.041
 	political_power_factor = 0.125
 }
 

--- a/common/modifiers/00_static_modifiers.txt
+++ b/common/modifiers/00_static_modifiers.txt
@@ -11,8 +11,7 @@ weather_rain_light = { # on Region
 	naval_hit_chance = -0.05
 	naval_retreat_speed = 0.05
 	naval_speed_factor = -0.05
-	naval_strike = -0.2				   
-	local_org_regain = -0.05
+	naval_strike = -0.2
 }
 weather_rain_heavy = { # on Region
 	air_accidents = 0.3
@@ -122,9 +121,7 @@ weather_extreme_hot = { # on Province
 	army_attack_factor = -0.1
 	heat_attrition = 0.2
 	supply_consumption_factor = 0.5
-    army_attack_factor = -0.1
 	local_org_regain = -0.1
-	supply_consumption_factor = 0.5
 	truck_attrition_factor = 0.1
 }
 weather_ground_snow_medium = { # on Province

--- a/common/national_focus/australia.txt
+++ b/common/national_focus/australia.txt
@@ -2961,19 +2961,24 @@ focus_tree = {
 			if = {
 				limit = { has_idea = AST_great_depression_1 }
 				remove_ideas = AST_great_depression_1
-				add_ideas = AST_all_in
+				swap_ideas = {
+					remove_idea = AST_invest_in_victory_2
+					add_idea = AST_invest_in_victory_3
+				}
 			}
 			if = {
 				limit = { has_idea = AST_great_depression_2 }
 				remove_ideas = AST_great_depression_2
-				add_ideas = AST_all_in
-				
+				swap_ideas = {
+					remove_idea = AST_invest_in_victory_2
+					add_idea = AST_invest_in_victory_3
+				}	
 			}
 			if = {
 				limit = { has_idea = AST_great_depression_3 }
 				swap_ideas = {
 					remove_idea = AST_great_depression_3
-					add_idea = AST_all_in
+					add_idea = AST_invest_in_victory_3
 				}
 			}
 			remove_ideas = AST_conscript_malus

--- a/common/national_focus/bulgaria.txt
+++ b/common/national_focus/bulgaria.txt
@@ -263,7 +263,6 @@ focus_tree = {
 		x = 0
 		y = 1
 		cost = 10
-		mutually_exclusive = { focus = BUL_utmost_optimization }
 
 		available = {
 			NOT = { has_government = democratic }
@@ -344,13 +343,12 @@ focus_tree = {
 	focus = {
 		id = BUL_utmost_optimization
 
-		prerequisite = { focus = BUL_increase_industry_investments focus = BUL_expand_the_tobacco_industry }
+		prerequisite = { focus = BUL_increase_industry_investments }
 		icon = GFX_focus_generic_industry_3
 		relative_position_id = BUL_increase_industry_investments
 		x = 0
 		y = 2
 		cost = 10
-		mutually_exclusive = { focus = BUL_nationalization }
 
 		available = {
 			NOT = { has_idea = BUL_second_national_catastrophe }			

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -1755,7 +1755,22 @@
 		available_if_capitulated = no
 
 		complete_tooltip = {
-
+			set_politics = {
+				ruling_party = neutrality
+				elections_allowed = no
+			}
+			add_country_leader_trait = camarilla_leader
+			create_country_leader = {
+				name = "Carol II"
+				desc = "POLITICS_CAROL_II_DESC"
+				picture = GFX_Portrait_romania_Carol_II				
+				expire = "1965.1.1"
+				ideology = despotism
+				traits = {
+				}
+				id = 550
+			}
+			news_event = { id = news.484 }
 		}
 
 		completion_reward = {
@@ -1774,7 +1789,6 @@
 				}
 				id = 550
 			}
-			add_ideas = ROM_king_carol_ii_consumer_penalty
 			news_event = { id = news.484 }
 		}
 	}

--- a/common/national_focus/vichy_france.txt
+++ b/common/national_focus/vichy_france.txt
@@ -30,6 +30,7 @@
 
 		completion_reward = {
 			add_to_tech_sharing_group = axis_research
+			add_timed_idea = { idea = EFR_german_industry_support days = 300 }
 			hidden_effect = {
 				load_oob = EFR_armistice_army
 				every_owned_state = {

--- a/descriptor.mod
+++ b/descriptor.mod
@@ -4,6 +4,7 @@ replace_path="history/countries"
 replace_path="history/states"
 replace_path="map/strategicregions"
 replace_path="map/supplyareas"
+replace_path="common/modifiers/00_static_modifiers"
 tags={
 	"Historical"
 	"Balance"

--- a/history/countries/ROM - Romania.txt
+++ b/history/countries/ROM - Romania.txt
@@ -115,7 +115,6 @@ recruit_character = ROM_ion_antonescu
 recruit_character = ROM_horia_macellariu
 recruit_character = ROM_gheorghe_avramescu
 recruit_character = ROM_corneliu_zelea_codreanu
-recruit_character = ROM_gheorge_potopeanu
 recruit_character = ROM_gheorghe_potopeanu
 recruit_character = ROM_david_popescu
 recruit_character = ROM_istrate_micescu

--- a/localisation/english/ideas_l_english.yml
+++ b/localisation/english/ideas_l_english.yml
@@ -2145,6 +2145,7 @@
  AST_great_depression_2:0 "Great Depression"
  AST_great_depression_3:0 "Great Depression"
  AST_invest_in_victory_2:0 "Invest in Victory"
+ AST_invest_in_victory_3:0 "All In!"
  AST_all_in:0 "All In!"
  AST_commits_india_idea:0 "Australia invests in the Jewel"
  AST_commits_india_idea_desc:0 ""

--- a/localisation/english/ideas_l_english.yml
+++ b/localisation/english/ideas_l_english.yml
@@ -81,6 +81,7 @@
  EFR_combat:0 "Special Forces Training"
  EFR_air:0 "No Industry for Air"
  EFR_production_debuff:0 "No Industry for Armor"
+ EFR_german_industry_support:0 "German Fueled Revanchism"
  EFR_naval_bonus:0 "Build the Navy"
  EFR_petain:0 "Philippe Pétain Government"
  

--- a/localisation/english/wtt_decisions_l_english.yml
+++ b/localisation/english/wtt_decisions_l_english.yml
@@ -293,6 +293,8 @@
  desperate_defense_desc:0 "We can't fall back any further. Our soldiers have to dig in and hold the line."
  war_bonds:0 "War Bonds"
  war_bonds_desc:0 "We need more resources for our war economy, and war bonds are just the way to obtain these."
+ war_bonds_cancel:0 "Cancel War Bonds"
+ war_bonds_cancel_desc:0 "We need more resources for our civilians, we must end our war bonds iniative."
  CHI_lessons_of_war:0 "Lessons of War"
  CHI_bolster_our_ranks:0 "Bolster Our Ranks"
  CHI_industrial_evacuations_from_beijing:0 "Industrial Evacuations from Beijing"


### PR DESCRIPTION
This is part 1 of industry changes for the entire mod.

Part one focuses mainly on Consumer Goods adjustments, and minor nations.

(Some fixes from things forgotten as well)

most (if not all) changes are based on 3 assumptions
1. nation has War Eco (at war generally in 1939)
2. 100% stability for potential maximum benefit
3. war bonds being active

There are "ways" to get lower CGs - however I at least made the decision (when doing these changes) that those avenues all have trade-offs to consider.