### PR TITLE
Spawn in divisions

### DIFF
--- a/common/national_focus/germany.txt
+++ b/common/national_focus/germany.txt
@@ -5053,35 +5053,35 @@ focus_tree = {
 				every_state = {
 					limit = { state = 202 }
 					create_unit = {
-						division = "name = \"1st Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 0.1" 
+						division = "name = \"1st Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = GER
 					}	
 					create_unit = {
-						division = "name = \"2nd Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 0.1" 
+						division = "name = \"2nd Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = GER
 					}	
 					create_unit = {
-						division = "name = \"3rd Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 0.1" 
+						division = "name = \"3rd Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = GER
 					}	
 					create_unit = {
-						division = "name = \"4th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 0.1" 
+						division = "name = \"4th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = GER
 					}	
 					create_unit = {
-						division = "name = \"5th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 0.1" 
+						division = "name = \"5th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = GER
 					}	
 					create_unit = {
-						division = "name = \"6th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 0.1" 
+						division = "name = \"6th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = GER
 					}	
 					create_unit = {
-						division = "name = \"7th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 0.1" 
+						division = "name = \"7th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = GER
 					}	
 					create_unit = {
-						division = "name = \"8th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 0.1" 
+						division = "name = \"8th Cossack Cavalry Corp\" division_template = \"Cossack Cavalry Corp\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = GER
 					}	
 				}

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -3293,25 +3293,17 @@ focus_tree = {
 				random_owned_controlled_state = {
 					prioritize = { 219 }
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
+					}		
 				}
 				if = {
 					limit = {
@@ -3320,25 +3312,17 @@ focus_tree = {
 					random_owned_controlled_state = {
 						prioritize = { 219 }
 						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 							owner = SOV
 						}	
 						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 							owner = SOV
 						}	
 						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 							owner = SOV
-						}	
-						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-							owner = SOV
-						}	
-						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Medium\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-							owner = SOV
-						}	
+						}
 					}
 				}
 			}
@@ -3438,23 +3422,11 @@ focus_tree = {
 				random_owned_controlled_state = {
 					prioritize = { 219 }
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 				}
@@ -3465,25 +3437,13 @@ focus_tree = {
 					random_owned_controlled_state = {
 						prioritize = { 219 }
 						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 							owner = SOV
 						}	
 						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 0.6 start_equipment_factor = 1.0" 
 							owner = SOV
-						}	
-						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-							owner = SOV
-						}	
-						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-							owner = SOV
-						}	
-						create_unit = {
-							division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Mekhanizirovaniy Korpus Heavy\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-							owner = SOV
-						}	
+						}
 					}
 				}
 			}
@@ -3905,43 +3865,27 @@ focus_tree = {
 				random_owned_controlled_state = {
 					prioritize = { 219 }
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 1.5 start_equipment_factor = 0.3" 
+						division = "name = \"Mekhanizirovaniy Korpus\" division_template = \"Motorized Rifle Corps\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}					
 				}
@@ -6080,35 +6024,19 @@ focus_tree = {
 				random_owned_controlled_state = {
 					prioritize = { 219 }
 					create_unit = {
-						division = "name = \"1. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 1.0 start_equipment_factor = 0.3" 
+						division = "name = \"1. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"2. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 1.0 start_equipment_factor = 0.3" 
+						division = "name = \"2. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"3. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 1.0 start_equipment_factor = 0.3" 
+						division = "name = \"3. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}	
 					create_unit = {
-						division = "name = \"4. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 1.0 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"5. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 1.0 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"6. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 1.0 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"7. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 1.0 start_equipment_factor = 0.3" 
-						owner = SOV
-					}	
-					create_unit = {
-						division = "name = \"8. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 1.0 start_equipment_factor = 0.3" 
+						division = "name = \"4. Tankoviy Korpus\" division_template = \"Tankoviy Korpus Reformed\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = SOV
 					}							
 				}

--- a/common/national_focus/uk.txt
+++ b/common/national_focus/uk.txt
@@ -9482,19 +9482,19 @@ focus_tree = {
 				every_state = {
 					limit = { state = 126 }
 					create_unit = {
-						division = "name = \"1. Sheffield Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"1. Sheffield Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"2. Newcastle Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"2. Newcastle Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"3. Cardiff Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"3. Cardiff Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"4. Edinburgh Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"4. Edinburgh Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 				}	
@@ -10902,51 +10902,35 @@ focus_tree = {
 				every_state = {
 					limit = { state = 126 }
 					create_unit = {
-						division = "name = \"5. London Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"5. London Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.2 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"6. Birmingham Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"6. Birmingham Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.2 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"7. Liverpool Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"7. Liverpool Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.2 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"8. Dover Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"8. Dover Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.2 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"9. Bristol Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"9. Bristol Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.2 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"10. Glasgow Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"10. Glasgow Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.2 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"11. Hull Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"11. Hull Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.2 start_equipment_factor = 1.0" 
 						owner = ENG
 					}	
 					create_unit = {
-						division = "name = \"12. Portsmouth Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
-						owner = ENG
-					}	
-					create_unit = {
-						division = "name = \"13. Plymouth Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
-						owner = ENG
-					}		
-					create_unit = {
-						division = "name = \"14. Norwich Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
-						owner = ENG
-					}
-					create_unit = {
-						division = "name = \"15. Manchester Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
-						owner = ENG
-					}
-					create_unit = {
-						division = "name = \"16. Leeds Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.0 start_equipment_factor = 0.8" 
+						division = "name = \"12. Portsmouth Home Guard-Battalion\" division_template = \"Home Guard\" start_experience_factor = 0.2 start_equipment_factor = 1.0" 
 						owner = ENG
 					}
 				}

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -1324,35 +1324,19 @@ focus_tree = {
 				every_state = {
 					limit = { state = 378 }
 					create_unit = {
-						division = "name = \"1st Marine Division\" division_template = \"USMC Division\" start_experience_factor = 1.5 start_equipment_factor = 0.5" 
+						division = "name = \"1st Marine Division\" division_template = \"USMC Division\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = USA
 					}	
 					create_unit = {
-						division = "name = \"2nd Marine Division\" division_template = \"USMC Division\" start_experience_factor = 1.5 start_equipment_factor = 0.5" 
+						division = "name = \"2nd Marine Division\" division_template = \"USMC Division\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = USA
 					}	
 					create_unit = {
-						division = "name = \"3rd. Marine Division\" division_template = \"USMC Division\" start_experience_factor = 1.5 start_equipment_factor = 0.5" 
+						division = "name = \"3rd. Marine Division\" division_template = \"USMC Division\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = USA
 					}	
 					create_unit = {
-						division = "name = \"4th. Marine Division\" division_template = \"USMC Division\" start_experience_factor = 1.5 start_equipment_factor = 0.5" 
-						owner = USA
-					}	
-					create_unit = {
-						division = "name = \"5th. Marine Division\" division_template = \"USMC Division\" start_experience_factor = 1.5 start_equipment_factor = 0.5" 
-						owner = USA
-					}	
-					create_unit = {
-						division = "name = \"6th. Marine Division\" division_template = \"USMC Division\" start_experience_factor = 1.5 start_equipment_factor = 0.5" 
-						owner = USA
-					}	
-					create_unit = {
-						division = "name = \"7th. Marine Division\" division_template = \"USMC Division\" start_experience_factor = 1.5 start_equipment_factor = 0.5" 
-						owner = USA
-					}	
-					create_unit = {
-						division = "name = \"8th. Marine Division\" division_template = \"USMC Division\" start_experience_factor = 1.5 start_equipment_factor = 0.5" 
+						division = "name = \"4th. Marine Division\" division_template = \"USMC Division\" start_experience_factor = 0.8 start_equipment_factor = 1.0" 
 						owner = USA
 					}	
 				}

--- a/localisation/english/focus_l_english.yml
+++ b/localisation/english/focus_l_english.yml
@@ -200,7 +200,7 @@
  uk_ire_focus_desc:0 "We should help Ireland rebuild after the trade war. It will help heal the rift between our nations.
 
  SOV_tank_designers_tt:0 "§R!!§G Gain Access to several tank designers.§W\n"
- cossacks_tt:0 "§YSpawn in Kiev 8 Cossacks cavalry Corps with very little equipement"
+ cossacks_tt:0 "§YSpawn in Kiev 8 Cossacks cavalry Corps"
  7_armoured_tt:0 "Spawn in Egypt The legendary §Y7th Armoured Division "Desert Rats""
  ENG_paratroopers_tt:0 "Spawn The §Y1st §Wand §Y6th §WAirborne Divisions"
  divisione_ariete_tt:0 "Spawn in 2 §Y"Ariete" §WTank Divisions, it was re-designed according to German standards. Despite being overall just a discrete division, it is the number one cause for pastaboos' history boners."

--- a/localisation/english/tooltips_l_english.yml
+++ b/localisation/english/tooltips_l_english.yml
@@ -77,7 +77,7 @@
  SOV_defense_of_moscow_forts_tt:0 "\nAdds §YLand Forts§! in a protective ring around §YMoscow§!. It will also add 10 §YMilitary Factories§! in §YMoscow§!.\n"
  SOV_defense_of_stalingrad_forts_tt:0 "\nAdds §YLand Forts§! in a protective ring around §YStalingrad§!. It will also add 10 §YMilitary Factories§! in §YStalingrad§!, as well as burn the infrastructure in 2 of the bordering states to slow down the German's advance.\n"
  SOV_defense_of_leningrad_forts_tt:0 "\nAdds §YLand Forts§! in a protective ring around §YLeningrad§!. It will also add 10 §YMilitary Factories§! in §YLeningrad§!, as well as burn the infrastructure in 2 of the bordering states to slow down the German's advance.\n" 
- SOV_create_unit_tank_corps_reformed_tt:0 "STAVKA has ordered that existing §YTank Corps§! are to be reformed according to a newly created standard. This decision will spawn 8 §YTank Divisions§! with §R30%§! starting equipment."
+ SOV_create_unit_tank_corps_reformed_tt:0 "STAVKA has ordered that existing §YTank Corps§! are to be reformed according to a newly created standard. This decision will spawn 4 §YTank Divisions§! with §FULL§! starting equipment."
  SOV_create_unit_rifle_corps_tt:0 "8 "§YMotorized Rifle Corps§!" will be created in Moscow, these are motorized infantry units containing 11 §YMotorized Infantry Battalions§! with 2 §YMotorized Artillery Battalions§!, 1 §YMotorized Heavy Artillery Battalion§! and 1 §Y Motorized Anti Tank Battalion§!."
  SOV_create_unit_marine_divisions_tt:0 "8 Elite "§YMarine Divisions§!" will be created in Sevastopol. These are Marine Divisions containing 11 §YMarine Battalions§! and 2 §YMotorized Artillery Battalions§!, 1 §YMotorized Heavy Artillery Battalion§! and 1 §Y Motorized Anti Tank Battalion§!."
  SOV_garrison_system_tt:0 ""
@@ -89,9 +89,9 @@
  SOV_plot_power_increase_25_tt:0 "Gain §G25%§! §YPlot Power§! towards fabricating a casus belli for the next purge."
  SOV_has_100_plot_power_for_focus_tt:0 "Requires you to have gathered §Y100%§! Plot Power before you can proceed with the next purge."
  SOV_does_not_have_100_plot_power_tt:0 "Can't be selected unless you have §Y100%§! Plot Power."
- SOV_tank_template_tt:0 "Grants a §Y30§! width §YMedium Tank§! template, and activates 5 divisions using it at 30% strength."
- SOV_heavy_tank_template_tt:0 "Grants a §Y30§! width §YHeavy Tank§! template, and activates 5 divisions using it at 30% strength."
- SOV_motorized_template_tt:0 "Grants a §Y30§! width §YMotorized Infantry§! template, and activates 10 divisions using it at 30% strength."
+ SOV_tank_template_tt:0 "Grants a §Y30§! width §YMedium Tank§! template, and activates 3 divisions using it at full strength."
+ SOV_heavy_tank_template_tt:0 "Grants a §Y30§! width §YHeavy Tank§! template, and activates 2 divisions using it at full strength."
+ SOV_motorized_template_tt:0 "Grants a §Y30§! width §YMotorized Infantry§! template, and activates 6 divisions using it at full strength."
  
  SOV_deploy_gulag_prisoners_tt:0 "Will deploy §Y2§! NKVD Divisions assembled from prisoners in our Gulag Prison Camps."
  

--- a/localisation/english/tooltips_l_english.yml
+++ b/localisation/english/tooltips_l_english.yml
@@ -162,7 +162,7 @@ CAN_CARRIERS_tt:0 "Will put in production 2 cruiser converted carriers represent
  USA_two_ocean_navy_act_bypass_tt:0 "Not enough building slots for §YMilitary Factories§! and §YDockyards§!."
  USA_fortify_islands_tt:0 "§YGuam§!, §YWake Island§!, §YMidway Island§!, §YJohnston Atoll§!, §YPhoenix Island§!, §YThe Line Islands§! and §YHawaii§!:\n Add §Y3 Coastal Fort§! in a province in the state.\n Add §Y4 Naval Base§! in a province in the state.\n Add §Y2 Air Base§!.\n Add §Y5 Anti-Air§!.\n Add §Y4 Infrastructure§!.\n Add §Y1 Fuel Silo§!.\n"
  USA_fortify_islands_2_tt:0 "§YGuam§!, §YWake Island§!, §YMidway Island§!, §YJohnston Atoll§!, §YPhoenix Island§!, §YThe Line Islands§! and §YHawaii§!:\n Add §Y3 Coastal Fort§! in a province in the state.\n Add §Y4 Naval Base§! in a province in the state.\n Add §Y2 Air Base§!.\n Add §Y5 Anti-Air§!.\n Add §Y4 Infrastructure§!.\n Add §Y1 Fuel Silo§!.\n Add §Y1 Radar Station§!.\n"
- USA_marine_divisions_tt:0 "8 §YUSMC Divisions§! will be §Gactivated§! in §YLos Angeles§!, these are veteran divisions with §Y50%§! equipment. Semper Fi!"
+ USA_marine_divisions_tt:0 "4 §YUSMC Divisions§! will be §Gactivated§! in §YLos Angeles§!, these are veteran divisions with §YFULL§! equipment. Semper Fi!"
  USA_marine_garrison_divisions_tt:0 "10 §YUSMC Garrison Divisions§! will be §Gactivated§! in §YLos Angeles§!, these are trained divisions with §Y100%§! equipment. Semper Fi!"
  USA_UK_has_to_accept_tt:0 "§YThe United Kingdom§! will have to §Gaccept§! this proposal for the event chain to have any further effects for us."
  USA_upgrade_naval_manufacturers_tt:0 "The U.S §YNaval Manufacturers§! are upgraded to provide §G25%§! extra §YDockyard Output§!."

--- a/localisation/english/tooltips_l_english.yml
+++ b/localisation/english/tooltips_l_english.yml
@@ -102,7 +102,7 @@
  SOV_gulag_inmates_20k_tt:0 "Orders §G20000§! new §YGulag Inmates§! that can be used to improve the §YGulag Economy§!."
  ############ENG TOOLTIPS##############
 
- ENG_home_guard_tt:0 "§YSpawns 12 "Home Guard" Infantry Divsions In Britian.§!"
+ ENG_home_guard_tt:0 "§YSpawns 8 "Home Guard" Infantry Divsions In Britian.§!"
  ENG_focus_boost_tt:0 "\nIf boosted using £decision_icon_small §HAdditional Funding for the Next Project§! the effect of this focus will change to the following:\n"
  air_defense_focus_tt:0 "Set maximum §YAnti-Air§! in §YGreater London Area§!, §YWest Midlands§!, and §YGloucestershire§!"
  air_defense_focus_built_max_tt:0 "Set maximum §YAnti-Air§! in §YGreater London Area§!, §YWest Midlands§!, §YGloucestershire§!, §YSussex§!, §YYorkshire§!, and §YLancashire§!."


### PR DESCRIPTION
Focuses (that I could find) that give spawn-in divisions adjusted.

generally reduced the amount of divisions that spawn as well as reduce the experience, but they are all fully equipped now.

Please let me know if any focuses have been missed, there are some focuses that I did not change as they work differently when spawning in divisions.
1. german focus that gives 4 tank divs - not sure where to look (or we are to change it
2. biritsh 7th armoured division - same as above.