### PR TITLE
General Army/Field marshal changes

### DIFF
--- a/common/defines/00_defines.lua
+++ b/common/defines/00_defines.lua
@@ -747,11 +747,11 @@ NMilitary = {
 	WAR_SCORE_LEND_LEASE_RECEIVED_IC_FACTOR = 0.001,  			-- war score deducted for every IC of lend lease received from allies
 	WAR_SCORE_LEND_LEASE_RECEIVED_FUEL_FACTOR = 0.001, 		-- war score deducted for every 100 units of fuel lend lease received from allies
 
-	CORPS_COMMANDER_DIVISIONS_CAP = 24,			-- how many divisions a corps commander is limited to. 0 = inf, < 0 = blocked
+	CORPS_COMMANDER_DIVISIONS_CAP = 40,			-- how many divisions a corps commander is limited to. 0 = inf, < 0 = blocked
 	DIVISION_SIZE_FOR_XP = 8,                   -- how many battalions should a division have to count as a full divisions when calculating XP stuff
 	CORPS_COMMANDER_ARMIES_CAP = -1,			-- how many armies a corps commander is limited to. 0 = inf, < 0 = blocked
-	FIELD_MARSHAL_DIVISIONS_CAP = 30,			-- how many divisions a field marshall is limited to. 0 = inf, < 0 = blocked
-	FIELD_MARSHAL_ARMIES_CAP = 5,				-- how many armies a field marshall is limited to. 0 = inf, < 0 = blocked
+	FIELD_MARSHAL_DIVISIONS_CAP = 50,			-- how many divisions a field marshall is limited to. 0 = inf, < 0 = blocked
+	FIELD_MARSHAL_ARMIES_CAP = 3,				-- how many armies a field marshall is limited to. 0 = inf, < 0 = blocked
 
 	UNIT_LEADER_GENERATION_CAPITAL_CONTINENT_FACTOR = 100, --Integer factor to multiply manpower.
 

--- a/common/unit_leader/00_traits.txt
+++ b/common/unit_leader/00_traits.txt
@@ -835,7 +835,7 @@ leader_traits = {
 			terrain_penalty_reduction = 0.2
 			acclimatization_cold_climate_gain_factor = 0.1
 			acclimatization_hot_climate_gain_factor = 0.1
-			max_commander_army_size = -4
+			max_commander_army_size = -6
 		}
 		
 		ai_will_do = {
@@ -982,7 +982,6 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
-				max_commander_army_size = -2
 			}
 		}
 		
@@ -1005,7 +1004,6 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
-				max_commander_army_size = -2
 			}
 		}
 		
@@ -1028,7 +1026,6 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
-				max_commander_army_size = -2
 			}
 		}
 		
@@ -1051,7 +1048,6 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
-				max_commander_army_size = -2
 			}
 		}
 		
@@ -1074,7 +1070,6 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
-				max_commander_army_size = -2
 			}
 		}
 		
@@ -1097,7 +1092,6 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
-				max_commander_army_size = -2
 			}
 		}
 		
@@ -1120,7 +1114,6 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
-				max_commander_army_size = -2
 			}
 		}
 		

--- a/common/unit_leader/00_traits.txt
+++ b/common/unit_leader/00_traits.txt
@@ -454,6 +454,7 @@ leader_traits = {
 		cost = 1000
 		field_marshal_modifier = {
 			max_dig_in_factor = 0.30
+			max_army_group_size = 1
 		}
 		
 		ai_will_do = {
@@ -497,6 +498,7 @@ leader_traits = {
 		cost = 1000
 		field_marshal_modifier = {
 			max_planning = 0.1
+			max_army_group_size = 1
 		}
 		
 		slot = army_chief
@@ -581,6 +583,7 @@ leader_traits = {
 		cost = 1000
 		field_marshal_modifier = {
 			land_reinforce_rate = 0.02
+			max_army_group_size = 1
 		}
 		
 		slot = army_chief
@@ -626,7 +629,7 @@ leader_traits = {
 		cost = 1000
 		
 		field_marshal_modifier = {
-			max_army_group_size = 2
+			max_army_group_size = 3
 		}
 		
 		slot = army_chief

--- a/common/unit_leader/00_traits.txt
+++ b/common/unit_leader/00_traits.txt
@@ -65,7 +65,7 @@ leader_traits = {
 		}
 		
 		non_shared_modifier = {
-			experience_gain_factor = -0.25
+			experience_gain_factor = -0.1
 		}
 	}	
 	
@@ -89,8 +89,8 @@ leader_traits = {
 		trait_type = personality_trait
 
 		corps_commander_modifier = {
-			max_commander_army_size = 48
-			experience_gain_factor = -0.50
+			max_commander_army_size = 60
+			experience_gain_factor = -0.25
 		}
 		new_commander_weight = {
 			factor = 0
@@ -687,7 +687,7 @@ leader_traits = {
 
 		modifier = {
 			cavalry_attack_factor = 0.10	
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		slot = high_command
@@ -717,7 +717,7 @@ leader_traits = {
 		modifier = {
 			motorized_attack_factor = 0.1
 			mechanized_attack_factor = 0.1
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		ai_will_do = {
@@ -742,7 +742,7 @@ leader_traits = {
 		
 		modifier = {
 			army_infantry_defence_factor = 0.10
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		slot = high_command
@@ -766,7 +766,7 @@ leader_traits = {
 		cost = 1000
 		
 		corps_commander_modifier = {
-			max_commander_army_size = 6
+			max_commander_army_size = 8
 		}
 		
 		slot = high_command
@@ -835,7 +835,7 @@ leader_traits = {
 			terrain_penalty_reduction = 0.2
 			acclimatization_cold_climate_gain_factor = 0.1
 			acclimatization_hot_climate_gain_factor = 0.1
-			max_commander_army_size = -2
+			max_commander_army_size = -4
 		}
 		
 		ai_will_do = {
@@ -896,7 +896,7 @@ leader_traits = {
 			fort = {
                 attack = 0.05
             }
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		slot = high_command
@@ -924,7 +924,7 @@ leader_traits = {
 		modifier = {
 			army_armor_attack_factor = 0.05 
 			army_armor_defence_factor = 0.05
-			max_commander_army_size = -2		
+			max_commander_army_size = -4		
 		}
 		
 		slot = high_command
@@ -956,7 +956,7 @@ leader_traits = {
 
 		modifier = {
 			out_of_supply_factor = -0.5
-			max_commander_army_size = -2
+			max_commander_army_size = -4
 		}
 
 		slot = high_command
@@ -982,6 +982,7 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
+				max_commander_army_size = -2
 			}
 		}
 		
@@ -1004,6 +1005,7 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
+				max_commander_army_size = -2
 			}
 		}
 		
@@ -1026,6 +1028,7 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
+				max_commander_army_size = -2
 			}
 		}
 		
@@ -1048,6 +1051,7 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
+				max_commander_army_size = -2
 			}
 		}
 		
@@ -1070,6 +1074,7 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
+				max_commander_army_size = -2
 			}
 		}
 		
@@ -1092,6 +1097,7 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
+				max_commander_army_size = -2
 			}
 		}
 		
@@ -1114,6 +1120,7 @@ leader_traits = {
 				movement = 0.05
 				attack = 0.1
 				defence = 0.1
+				max_commander_army_size = -2
 			}
 		}
 		
@@ -1135,7 +1142,7 @@ leader_traits = {
 		modifier = {
 			amphibious_invasion = 0.3 # 30% faster invasions
 			invasion_preparation = -0.3
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		ai_will_do = {
@@ -1165,7 +1172,7 @@ leader_traits = {
 		modifier = {
 			army_armor_defence_factor = 0.1
 			army_armor_attack_factor = 0.1
-			max_commander_army_size = -2
+			max_commander_army_size = -4
 		}
 		
 		custom_effect_tooltip = INCREASED_BLITZ_AND_ENCIRCLEMENT_CHANCE
@@ -1193,7 +1200,7 @@ leader_traits = {
 		modifier = {
 			motorized_defence_factor = 0.1
 			mechanized_defence_factor = 0.1
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 				
 		ai_will_do = {
@@ -1215,7 +1222,7 @@ leader_traits = {
 		    army_armor_attack_factor = 0.05
 			mechanized_attack_factor = 0.1
 			motorized_attack_factor = 0.1
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		custom_effect_tooltip = INCREASED_BLITZ_AND_ENCIRCLEMENT_CHANCE
@@ -1245,7 +1252,7 @@ leader_traits = {
 		modifier = {
 			cavalry_attack_factor = 0.10
 			cavalry_defence_factor = 0.15
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		ai_will_do = {
@@ -1277,7 +1284,7 @@ leader_traits = {
 			fort = {
 				attack = 0.1
 			}
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		enable_ability = siege_artillery
 		
@@ -1328,7 +1335,7 @@ leader_traits = {
 
 		modifier = {
 			army_infantry_attack_factor = 0.15
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		ai_will_do = {
@@ -1375,7 +1382,7 @@ leader_traits = {
 
 		modifier = {
 			extra_marine_supply_grace = 240
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		enable_ability = faster_naval_invasion_planning
@@ -1398,7 +1405,7 @@ leader_traits = {
 
 		modifier = {
 			shore_bombardment_bonus = 0.25
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		ai_will_do = {
@@ -1442,7 +1449,7 @@ leader_traits = {
 
 		modifier = {
 			extra_paratrooper_supply_grace = 240
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		enable_ability = glider_planes
@@ -1468,7 +1475,7 @@ leader_traits = {
 		modifier = {
 			cas_damage_reduction = 0.5
 			air_superiority_bonus_in_combat = -0.5
-			max_commander_army_size = -2
+			max_commander_army_size = -3
 		}
 		
 		slot = high_command


### PR DESCRIPTION
Intent: Make individual Army command structure "micro" different. should lead to less army management - but more field management. Added increase army group sizes to some field marshal traits.

Army command: 24 >> 40
field marshal: 5 >> 3
Max division count per field marshal stays at 120 divisions (before traits)

traits: reductions increases (from -2 to -3 or -4, adaptable is now -6)

reservist: +48 > +60
xp gain -50% > -25%

old guard: xp gain -25% > -10%

Wanted to add army command reductions to terrain traits - but seems to give an error.