### PR TITLE
op intergrity / amphib tanks / amtrac nerfs

### DIFF
--- a/common/technologies/air_doctrine.txt
+++ b/common/technologies/air_doctrine.txt
@@ -1150,7 +1150,7 @@ technologies = {
 		xor = { formation_flying air_superiority }	
 
 		# EFFECT ########
-		air_interception_detect_factor = 0.20
+		air_interception_detect_factor = 0.15
 		air_mission_xp_gain_factor = 0.1
 							  
 		###########
@@ -1189,7 +1189,7 @@ technologies = {
 	fighter_baiting = {
 
 		# EFFECT ########
-		air_intercept_efficiency = 0.2
+		air_intercept_efficiency = 0.15
 		air_ace_generation_chance_factor = 0.1
 		###########
 		

--- a/common/units/equipment/amphibious_mechanized.txt
+++ b/common/units/equipment/amphibious_mechanized.txt
@@ -17,7 +17,7 @@ equipments = {
 		reliability = 0.8
 		
 		#Defensive Abilities
-		defense = 13
+		defense = 12
 		breakthrough = 12
 		hardness = 0.4
 		armor_value = 9
@@ -26,7 +26,7 @@ equipments = {
 		ap_attack = 20
 		air_attack = 0.3
 		soft_attack = 8
-		hard_attack = 4
+		hard_attack = 3
 
 		#Space taken in convoy
 		lend_lease_cost = 5
@@ -61,7 +61,7 @@ equipments = {
 		maximum_speed = 9
 
 		#Defensive Abilities
-		defense = 17
+		defense = 16
 		breakthrough = 16
 		hardness = 0.5
 		armor_value = 14
@@ -70,7 +70,7 @@ equipments = {
 		ap_attack = 25
 		air_attack = 0.4
 		soft_attack = 9
-		hard_attack = 5
+		hard_attack = 4
 
 		build_cost_ic = 22
 		resources = {

--- a/common/units/equipment/tank_amphibious.txt
+++ b/common/units/equipment/tank_amphibious.txt
@@ -83,7 +83,7 @@ equipments = {
 	# 	maximum_speed = 6.4
 
 	# 	#Defensive Abilities
-	# 	defense = 21
+	# 	defense = 20
 	# 	breakthrough = 60
 	# 	hardness = 0.8
 	# 	armor_value = 60

--- a/common/units/equipment/tank_amphibious.txt
+++ b/common/units/equipment/tank_amphibious.txt
@@ -27,14 +27,14 @@ equipments = {
 	# 	reliability = 0.69
 
 	# 	#Defensive Abilities
-	# 	defense = 21
-	# 	breakthrough = 52
+	# 	defense = 18
+	# 	breakthrough = 50
 	# 	hardness = 0.8
 	# 	armor_value = 50
 
 	# 	#Offensive Abilities
 	# 	soft_attack = 40
-	# 	hard_attack = 25
+	# 	hard_attack = 22
 	# 	ap_attack = 64
 	# 	air_attack = 0
 
@@ -83,14 +83,14 @@ equipments = {
 	# 	maximum_speed = 6.4
 
 	# 	#Defensive Abilities
-	# 	defense = 23
+	# 	defense = 21
 	# 	breakthrough = 60
 	# 	hardness = 0.8
 	# 	armor_value = 60
 
 	# 	#Offensive Abilities
 	# 	soft_attack = 45
-	# 	hard_attack = 30
+	# 	hard_attack = 27
 	# 	ap_attack = 74
 	# 	air_attack = 0	
 		


### PR DESCRIPTION
Interception is too strong atm and the doctrine gives way too many buffs to it. The doctrine is still the best for air trades with better fighter detection and such, but the interception will be a bit less absurd.

Amphib tanks have a lot of stats, but they are pretty expensive having simular ic cost to heavy tanks. Nerfing the defense and hard attack will make them be weaker vs other tanks letting heavy tanks be able to beat them head on if you don't have any TDs to support them. 

Amtracs are better than mechs, but again, they are a lot more expensive, so I hit their defense and hard attack for the same reason as the amphib tanks. 