### PR TITLE
division deploy speed and mobilization

### DIFF
--- a/common/defines/00_defines.lua
+++ b/common/defines/00_defines.lua
@@ -341,7 +341,7 @@ NCountry = {
 	BASE_SURRENDER_LIMIT = 0.8,						-- Base level of occupation required for country surrender
 	SURRENDER_LIMIT_MULT_FOR_COUNTRIES_WITH_NO_CORES = 0.7, -- Countries with no owned cores will their surrender level multiplied by this amount
 	MIN_SURRENDER_LIMIT = 0.1,						-- Minimum non-forced surrender limit. valid 0-1
-	BASE_MOBILIZATION_SPEED = 0.01,					-- Base speed of manpower mobilization  #in 1/1000 of 1 %
+	BASE_MOBILIZATION_SPEED = 0.04,					-- Base speed of manpower mobilization  #in 1/1000 of 1 %
 
 	INTERCEPTION_WAR_SUPPORT_SCALE = 0.00002,		-- Scaling of interceptions to war support impact
 	INTERCEPTION_BOMBING_WAR_SUPPORT_IMPACT = 0.3,	-- Max impact of interceptions on the war support

--- a/common/ideas/GDU_ideas.txt
+++ b/common/ideas/GDU_ideas.txt
@@ -1830,7 +1830,7 @@ ideas = {
 				experience_gain_carrier_training_factor = 10.0
 				experience_gain_heavy_cruiser_training_factor = 10.0
 				experience_gain_light_cruiser_training_factor = 10.0
-				training_time_factor = -0.45
+				training_time_factor = -0.70
 			}
 		}
 		


### PR DESCRIPTION
Feedback from other groups trying out the mod (read, less skilled and newer players). One that I think is both reasonable and easy to change is pre-war recruitment getting the divs out and ready for war using peacetime training.

Mobilization speed is dreadfully low