### PR TITLE
Feb. 10-12 game feedback changes

### DIFF
--- a/common/defines/00_defines.lua
+++ b/common/defines/00_defines.lua
@@ -383,7 +383,7 @@ NCountry = {
 	PROPAGANDA_WAR_SUPPORT_DAILY_DECAY = 0.001,		-- Amount of war support recovered daily from war support effort
 
 	NUM_DAYS_TO_FULLY_DELETE_STOCKPILED_EQUIPMENT = 999,	 -- time in days to fully delete equipments from stockpile. when you delete an equipment, they go to a temporary hidden pool which still can be seized
-	AIR_SUPPLY_CONVERSION_SCALE = 0.6,				-- Conversion scale for planes to air supply
+	AIR_SUPPLY_CONVERSION_SCALE = 0.4,				-- Conversion scale for planes to air supply
 	AIR_SUPPLY_DROP_EXPIRATION_HOURS = 168,			-- Air drop length after being dropped
 	STARTING_COMMAND_POWER = 0.0,					-- starting command power for every country
 	BASE_MAX_COMMAND_POWER = 200.0,					-- base value for maximum command power
@@ -1319,7 +1319,7 @@ NAir = {
 		0.0, -- NAVAL_KAMIKAZE
         0.0, -- PORT_STRIKE
 		0.0, -- ATTACK_LOGISTICS
-		0.2, -- AIR_SUPPLY
+		0.0, -- AIR_SUPPLY
 		0.0, -- TRAINING
 		0.0, -- NAVAL_MINES_PLANTING
 		0.0, -- NAVAL_MINES_SWEEPING
@@ -1329,7 +1329,7 @@ NAir = {
 	MISSION_FUEL_COSTS = {  -- fuel cost per plane for each mission
 		1.0, -- AIR_SUPERIORITY
 		1.0, -- CAS
-		0.2, -- INTERCEPTION
+		0.4, -- INTERCEPTION
 		1.0, -- STRATEGIC_BOMBER
 		1.0, -- NAVAL_BOMBER
 		1.0, -- DROP_NUKE
@@ -1472,7 +1472,7 @@ NNavy = {
 	NAVAL_TRANSFER_BASE_NAVAL_DIST_MULT = 20,						-- Multiplier for the cost of naval movement ( compared to land movement ) when deciding what ports to use for naval transfer
 	NAVAL_SUPREMACY_CAN_INVADE = 0.5,								-- required naval supremacy to perform invasions on an area
 	CARRIER_STACK_PENALTY = 5,										-- The most efficient is 4 carriers in combat. 5+ brings the penalty to the amount of wings in battle.
-	CARRIER_STACK_PENALTY_EFFECT = 0.2,								-- Each carrier above the optimal amount decreases the amount of airplanes being able to takeoff by such %.
+	CARRIER_STACK_PENALTY_EFFECT = 0.10,							-- Each carrier above the optimal amount decreases the amount of airplanes being able to takeoff by such %.
 	SHORE_BOMBARDMENT_CAP = 0.25,
 	ANTI_AIR_TARGETING = 0.9,                                       -- how good ships are at hitting aircraft
 	MIN_TRACTED_ASSIST_DAMAGE_RATIO = 0.05,							-- How much damage counts as assist damage

--- a/common/ideas/canada.txt
+++ b/common/ideas/canada.txt
@@ -283,8 +283,8 @@ ideas = {
 			picture = generic_goods_red_bonus
 			
 			modifier = {
-				industrial_capacity_factory = 0.5
-				industrial_capacity_dockyard = 0.5
+				industrial_capacity_factory = 0.05
+				industrial_capacity_dockyard = 0.05
 				consumer_goods_factor = -0.02
 			}
 		}

--- a/common/national_focus/india.txt
+++ b/common/national_focus/india.txt
@@ -6411,8 +6411,8 @@ focus_tree = {
 		}
 
 		available = {
-			NOT = {
-			controls_province = 1330
+			RAJ = {
+					surrender_progress > 0.1
 			}
 		}
 
@@ -6454,9 +6454,8 @@ focus_tree = {
 		}
 
 		available = {
-			NOT = {
-			controls_state = 640 #mandalay
-			controls_state = 288 #burma
+			RAJ = {
+					surrender_progress > 0.3
 			}
 		}
 

--- a/history/states/449-Libyan Coast.txt
+++ b/history/states/449-Libyan Coast.txt
@@ -4,7 +4,7 @@ state={
 	name="STATE_449" # El Agheila
 	manpower = 40431
 	
-	state_category = wasteland
+	state_category = pastoral
 
 	history={
 		owner = ITA

--- a/history/states/450-Benghasi.txt
+++ b/history/states/450-Benghasi.txt
@@ -4,7 +4,7 @@ state={
 	name="STATE_450"
 	manpower = 82535
 	
-	state_category = wasteland
+	state_category = pastoral
 
 	history={
 		owner = ITA

--- a/history/states/451-Derna.txt
+++ b/history/states/451-Derna.txt
@@ -4,7 +4,7 @@ state={
 	name="STATE_451"
 	manpower = 45628
 	
-	state_category = wasteland
+	state_category = pastoral
 
 	history={
 		owner = ITA

--- a/history/states/452-Marsa Matruh.txt
+++ b/history/states/452-Marsa Matruh.txt
@@ -4,7 +4,7 @@ state={
 	name="STATE_452"
 	manpower = 52556
 	
-	state_category = wasteland
+	state_category = pastoral
 
 	history={
 		owner = ENG

--- a/history/states/663-Cyrenaica.txt
+++ b/history/states/663-Cyrenaica.txt
@@ -3,7 +3,7 @@ state={
 	name="STATE_663"
 	manpower = 8808
 	
-	state_category = wasteland
+	state_category = pastoral
 
 	history={
 		owner = ITA

--- a/map/adjacencies.csv
+++ b/map/adjacencies.csv
@@ -230,7 +230,8 @@ From;To;Type;Through;start_x;start_y;stop_x;stop_y;adjacency_rule_name;Comment
 13258;1048;impassable;-1;-1;-1;-1;-1;;gibraltar;;;;
 4318;12789;impassable;-1;-1;-1;-1;-1;;burma;;;;
 4996;12789;impassable;-1;-1;-1;-1;-1;;burma;;;;
-4996;12898;impassable;-1;-1;-1;-1;-1;;burma;;;;
+4425;12898;impassable;-1;-1;-1;-1;-1;;burma;;;;
+4996;10863;impassable;-1;-1;-1;-1;-1;;burma;;;;
 4996;10863;impassable;-1;-1;-1;-1;-1;;burma;;;;
 10920;10863;impassable;-1;-1;-1;-1;-1;;burma;;;;
 12363;10863;impassable;-1;-1;-1;-1;-1;;burma;;;;


### PR DESCRIPTION
1. air supply reduced again, but overall it is still pretty good. 

2. removed burma road opening
Better to plug the hole. balance accordingly if an issue arises. Japan players typically learn naval invading is better anyway. It's a useless "division tax" for both Japan and the Allies and I also despise "skill check" things.

3. Changed some India focuses to be surrender progress based. state control requirements lead to Japans just ignoring the area and that is not the intention.
Subject to change based on future game reviews, but the surrender progress points for these focuses should feel pretty fair. First focus still requires singapore lost and last focus still requires states.

4. Africa States state category changed. this will improve local supply which should improve the cancer everyone feels there.
Wasteland was giving a -60% local supply effect. When you add on desert -70% local supply - shit was wild.
Pastoral gives -15% - this should help improve supply issues on all affected states.

5. Carrier stack penalty is increased (20% air >> 10% air being able to fly)
Went and did a test - and think this is a fair change for the time being. if *insert Japan and USA naval LARPers name*  wants 500 carrier planes to fly and do damage - stick to the right amount of carriers (with pacific designer that RH adjusted you can do it), or have 5000 planes in battle.

6. Canada war bonds idea fixed (forgot a 0)
The idea was not meant to give 50% output bonus, it was supposed to be 5% - I forgot a 0 because code looks the same after a couple hours.