### PR TITLE
rom oil change

### DIFF
--- a/common/decisions/GER.txt
+++ b/common/decisions/GER.txt
@@ -4203,6 +4203,9 @@ foreign_politics = {
 			hidden_effect = {
 				complete_national_focus = GER_romanian_oil
 			}
+			46 = {
+				add_dynamic_modifier = { modifier = germany_oil_control_modifier }
+			}
 			ROM = {
 				give_resource_rights = { receiver = GER state = 46 }
 			}

--- a/common/defines/00_defines.lua
+++ b/common/defines/00_defines.lua
@@ -669,8 +669,8 @@ NBuildings = {
 	OWNER_CHANGE_EXTRA_SHARED_SLOTS_FACTOR = 0.5, --Scale factor of extra shared slots when state owner change.
 	DESTRUCTION_COOLDOWN_IN_WAR = 30,	-- Number of days cooldown between removal of buildings in war times
 
-	INFRASTRUCTURE_RESOURCE_BONUS = 0.18, -- multiplicative resource bonus for each level of (non damaged) infrastructure
-	SUPPLY_ROUTE_RESOURCE_BONUS = 0.18,   -- multiplicative resource bonus for having a railway/naval connection to the capital
+	INFRASTRUCTURE_RESOURCE_BONUS = 0.20, -- multiplicative resource bonus for each level of (non damaged) infrastructure
+	SUPPLY_ROUTE_RESOURCE_BONUS = 0.15,   -- multiplicative resource bonus for having a railway/naval connection to the capital
 	INFRASTRUCTURE_MUD_EFFECT = -0.8, -- multiplicative effect on mud growth for max infra
 },
 

--- a/common/dynamic_modifiers/0_dynamic_modifiers.txt
+++ b/common/dynamic_modifiers/0_dynamic_modifiers.txt
@@ -179,6 +179,15 @@ romania_control_modifier = {
 	state_resources_factor = 0.15
 }
 
+germany_oil_control_modifier = {
+	enable = { always = yes }
+
+	icon = GFX_modifiers_sabotaged_resource
+	
+	state_resources_factor = 0.12
+	recruitable_population_factor = -0.1
+}
+
 yugoslavia_partisans_modifier = {
 	enable = { always = yes }
 

--- a/common/ideas/romania.txt
+++ b/common/ideas/romania.txt
@@ -22,10 +22,10 @@ ideas = {
 			    political_power_factor = 0.05
 				stability_factor = 0.1
 				local_resources_factor = 0.1
-				industrial_capacity_factory = 0.05
-				production_factory_max_efficiency_factor = 0.05
+				industrial_capacity_factory = 0.10
+				production_factory_max_efficiency_factor = 0.06
 				production_speed_buildings_factor = 0.025
-				min_export = 0.1
+				min_export = 0.05
 				conscription_factor = 0.05
 			}
 		}
@@ -50,10 +50,10 @@ ideas = {
 			    political_power_factor = 0.05
 				local_resources_factor = 0.2
 				consumer_goods_factor = -0.05
-				industrial_capacity_factory = 0.1
-				production_factory_max_efficiency_factor = 0.1
+				industrial_capacity_factory = 0.20
+				production_factory_max_efficiency_factor = 0.12
 				production_speed_buildings_factor = 0.1
-				min_export = 0.2
+				min_export = 0.1
 				conscription_factor = 0.1
 			}
 		}
@@ -77,9 +77,9 @@ ideas = {
 			modifier = {
 				fuel_gain_factor = 0.1
 				max_fuel_factor = 0.4
-				industrial_capacity_factory = 0.1
-				production_factory_max_efficiency_factor = 0.1
-				production_speed_buildings_factor = 0.1	
+				industrial_capacity_factory = 0.05
+				production_factory_max_efficiency_factor = 0.05
+				production_speed_buildings_factor = 0.05
 				conscription_factor = -0.02						
 			}
 		}
@@ -103,9 +103,9 @@ ideas = {
 			modifier = {
 				fuel_gain_factor = 0.20
 				max_fuel_factor = 0.5
-				industrial_capacity_factory = 0.15
-				production_factory_max_efficiency_factor = 0.15
-				production_speed_buildings_factor = 0.15	
+				industrial_capacity_factory = 0.10
+				production_factory_max_efficiency_factor = 0.10
+				production_speed_buildings_factor = 0.10	
 				conscription_factor = -0.05					
 			}
 		}

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -897,8 +897,7 @@
 		available_if_capitulated = yes
 
 		completion_reward = {
-			random_owned_controlled_state = {
-				prioritize = { 46 }
+			84 = {
 				add_extra_state_shared_building_slots = 4 
 				add_building_construction = {
 					type = industrial_complex

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -31,6 +31,7 @@
 
 		completion_reward = {
 			add_ideas = free_trade
+			add_political_power = 100
 		}
 	}
 
@@ -901,7 +902,7 @@
 				add_extra_state_shared_building_slots = 4 
 				add_building_construction = {
 					type = industrial_complex
-					level = 2 
+					level = 4
 					instant_build = yes 
 				}
 				add_resource = {
@@ -1022,7 +1023,7 @@
 		x = 1
 		y = 1
 		relative_position_id = ROM_improve_living_standards
-		cost = 15
+		cost = 10
 
 		available_if_capitulated = yes
 
@@ -1070,6 +1071,41 @@
 			remove_ideas = ROM_the_resource_curse_1
 			remove_ideas = ROM_industrialization_4 
  		}
+	}
+	
+	focus = {
+		id = ROM_royal_foundation
+		icon = GFX_focus_research
+		relative_position_id = ROM_improve_living_standards
+		prerequisite = { focus = ROM_the_romanian_miracle }
+		x = 1
+		y = 2
+
+		cost = 5
+
+		ai_will_do = {
+			factor = 9
+		}
+
+		available = {
+
+		}
+
+		bypass = {
+
+		}
+
+		cancel_if_invalid = yes
+		continue_if_invalid = no
+		available_if_capitulated = no
+
+		complete_tooltip = {
+
+		}
+
+		completion_reward = {
+			add_research_slot = 1 
+		}
 	}
 
 	focus = {
@@ -1967,41 +2003,6 @@
 		completion_reward = {
 			add_war_support = 0.1 
 			add_stability = 0.1 
-		}
-	}
-
-	focus = {
-		id = ROM_royal_foundation
-		icon = GFX_focus_research
-		relative_position_id = ROM_operetta_fascism
-		prerequisite = { focus = ROM_operetta_fascism focus = ROM_secure_our_territorial_integrity }
-		x = -2
-		y = 1
-
-		cost = 5
-
-		ai_will_do = {
-			factor = 9
-		}
-
-		available = {
-
-		}
-
-		bypass = {
-
-		}
-
-		cancel_if_invalid = yes
-		continue_if_invalid = no
-		available_if_capitulated = no
-
-		complete_tooltip = {
-
-		}
-
-		completion_reward = {
-			add_research_slot = 1 
 		}
 	}
 

--- a/history/countries/ROM - Romania.txt
+++ b/history/countries/ROM - Romania.txt
@@ -8,7 +8,7 @@ if = {
 		set_naval_oob = "ROM_1936_naval_legacy"
 	}
 }
-set_research_slots = 3
+set_research_slots = 4
 
 ROM = {
 	#Pick from list of the sane events first

--- a/history/states/46-Romania.txt
+++ b/history/states/46-Romania.txt
@@ -4,7 +4,7 @@ state={
 	name="STATE_46" # Muntenia
 	manpower = 4461400
 	resources={
-		oil = 35 # was: 70
+		oil = 50 # changed from 35 was: 70 in vanilla
 	}
 
 	state_category = city

--- a/history/states/46-Romania.txt
+++ b/history/states/46-Romania.txt
@@ -4,7 +4,6 @@ state={
 	name="STATE_46" # Muntenia
 	manpower = 4461400
 	resources={
-		steel = 10
 		oil = 35 # was: 70
 	}
 

--- a/history/states/82-Banat.txt
+++ b/history/states/82-Banat.txt
@@ -4,6 +4,7 @@ state={
 	name="STATE_82"
 	manpower = 941500
 	resources={
+		steel = 10
 		aluminium=4
 	}
 	

--- a/localisation/english/focus_l_english.yml
+++ b/localisation/english/focus_l_english.yml
@@ -4116,6 +4116,7 @@
  staunch_traditionalist:0 "Staunch Traditionalist"
  
  romania_control_modifier:0 "Romania Fascist Authority (Autonomous Region)"
+ germany_oil_control_modifier:0 "Germany seized our oil fields"
 
  GER_atlantikwall_tt_2:0 "§YAquitaine§!\n§YPoitou§!\n§YLoire§!\n§YBritanny§!\n§YNormandy§!\n§YPas de Calais§!\n§YVlaanderen§!\n§YHolland§!\n§YFriesland§!\n§YVestlandet§!\n"
  GER_westwall_tt:0 "Constructs §YLand Forts§! along the border with France, in each of the following states:\n"


### PR DESCRIPTION
moved resources into the mountain states. Germany adds a state modifier that benefits them when taking the oil. 

Made infra give more resource efficiency - an even 20% instead of a weird %. lowered supply route resource gain a bit. removing weird numbers basically.

Intent is to have it so if Romania goes stab plan, Germany can *yoink* the oil and still benefit from it instead of feeling like axis got shafted. Romania can still help increase it with better Infra (which they normally do anyway for their own benefit)