### PR TITLE
Snypers stuff

### DIFF
--- a/common/decisions/AST.txt
+++ b/common/decisions/AST.txt
@@ -57,7 +57,7 @@ operations = {
 		modifier = {
 			civilian_factory_use = 4
 		}
-		cost = 100
+		cost = 75
 		days_remove = 90
 		ai_will_do = {
 			factor = 1
@@ -65,17 +65,17 @@ operations = {
 		
 		remove_effect = {
 			add_equipment_to_stockpile = {
-				type = heavy_fighter_equipment
+				type = medium_plane_fighter_airframe
 				amount = 50
 				producer = ENG
 			}
 			add_equipment_to_stockpile = {
-				type = tac_bomber_equipment
+				type = medium_plane_airframe
 				amount = 50
 				producer = ENG
 			}
 			add_equipment_to_stockpile = {
-				type = nav_bomber_equipment
+				type = small_plane_naval_bomber_airframe
 				amount = 50
 				producer = ENG
 			}
@@ -101,7 +101,7 @@ operations = {
 		modifier = {
 			civilian_factory_use = 4
 		}
-		cost = 100
+		cost = 75
 		days_remove = 90
 		ai_will_do = {
 			factor = 1
@@ -109,18 +109,18 @@ operations = {
 		
 		remove_effect = {
 			add_equipment_to_stockpile = {
-				type = fighter_equipment
+				type = small_plane_airframe
 				amount = 50
 				producer = USA
 			}
 			add_equipment_to_stockpile = {
-				type = cas_equipment
+				type = small_plane_cas_airframe
 				amount = 50
 				producer = USA
 			}
 			add_equipment_to_stockpile = {
-				type = nav_bomber_equipment
-				amount = 50
+				type = large_plane_airframe
+				amount = 10
 				producer = USA
 			}
 			USA = {
@@ -144,7 +144,7 @@ operations = {
 		modifier = {
 			civilian_factory_use = 10
 		}
-		cost = 100
+		cost = 75
 		days_remove = 60
 		ai_will_do = {
 			factor = 1

--- a/common/ideas/australia.txt
+++ b/common/ideas/australia.txt
@@ -11,6 +11,9 @@ ideas = {
 				destroyer = {
 					build_cost_ic = -0.1 instant = yes
 				}
+				frigate = {
+					build_cost_ic = -0.1 instant = yes
+				}
 			}
 		}
 		AST_sub_prod = {
@@ -36,7 +39,7 @@ ideas = {
 			picture = generic_air_payment
 
 			modifier = {
-				consumer_goods_factor = 0.05
+				consumer_goods_factor = 0.03
 				political_power_cost = 0.2
 			}
 
@@ -198,7 +201,7 @@ ideas = {
 			picture = man_five_year_plan_tank
 
 			modifier = {
-				consumer_goods_factor = 0.05 
+				consumer_goods_factor = 0.03
 			}
 
 			equipment_bonus = {
@@ -688,7 +691,7 @@ ideas = {
 			picture = generic_volunteer_expedition_bonus
 
 			modifier = {
-				research_speed_factor = 0.025
+				research_speed_factor = 0.05
 			}
 		}
 		AST_Natives_law = {
@@ -704,7 +707,7 @@ ideas = {
 			picture = generic_volunteer_expedition_bonus
 
 			modifier = {
-				conscription = 0.005
+				conscription = 0.01
 				conscription_factor = 0.05
 			}
 		}
@@ -721,8 +724,10 @@ ideas = {
 			picture = generic_volunteer_expedition_bonus
 
 			modifier = {
-				weekly_manpower = 750
-				army_org_factor = 0.025
+				weekly_manpower = 500
+				army_org_factor = 0.05
+				army_attack_factor = 0.05
+				army_defence_factor = 0.05
 				supply_consumption_factor = -0.05
 			}
 		}

--- a/common/national_focus/australia.txt
+++ b/common/national_focus/australia.txt
@@ -217,6 +217,7 @@ focus_tree = {
 	
  	focus = {
 	    id = AST_tanks_main
+		mutually_exclusive = { focus = AST_special_forces_main }
 		icon = GFX_AST_tank_focus_icon
 		x = -2
 		y = 3
@@ -224,6 +225,7 @@ focus_tree = {
 		cost = 7.2
 		
 		prerequisite = { focus = AST_doctrine_investigation }
+		
 		
 		ai_will_do = {
 		  factor = 1
@@ -239,7 +241,7 @@ focus_tree = {
 			add_doctrine_cost_reduction = {
                 name = land_doc_bonus
                 cost_reduction = 0.5
-                uses = 3
+                uses = 2
                 category = land_doctrine
             }
 			add_tech_bonus = {
@@ -267,7 +269,6 @@ focus_tree = {
 		cost = 5
 		relative_position_id = AST_tanks_main
 		prerequisite = { focus = AST_tanks_main }
-		mutually_exclusive = { focus = AST_special_forces_main2 }
 		
 		ai_will_do = {
 		  factor = 1
@@ -325,6 +326,7 @@ focus_tree = {
 	
 	focus = {
 	    id = AST_special_forces_main
+		mutually_exclusive = { focus = AST_tanks_main } 
 		icon = GFX_goal_generic_special_forces
 		x = 0
 		y = 3
@@ -332,6 +334,7 @@ focus_tree = {
 		cost = 7.2
 		
 		prerequisite = { focus = AST_doctrine_investigation }
+		
 		
 		ai_will_do = {
 		  factor = 1
@@ -367,7 +370,6 @@ focus_tree = {
 		cost = 7.2
 		relative_position_id = AST_special_forces_main
 		prerequisite = { focus = AST_special_forces_main }
-		mutually_exclusive = { focus = AST_tanks_main2 }
 		
 		ai_will_do = {
 		  factor = 1
@@ -386,9 +388,16 @@ focus_tree = {
 				uses = 2
 				category = marine_tech 
 			}
+			add_doctrine_cost_reduction = {
+                name = land_doc_bonus
+                cost_reduction = 0.25
+                uses = 2
+                category = land_doctrine
+			
 		add_ideas = AST_mc	
 		}
 	}
+}
 	focus = {
 	    id = AST_special_forces_paratrooper
 		icon = GFX_focus_generic_paratrooper
@@ -2102,7 +2111,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = AST_standard_gauge_railway
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 5
@@ -2163,7 +2172,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = AST_standard_gauge_railway
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 5
@@ -2224,7 +2233,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = AST_standard_gauge_railway
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 5
@@ -2287,7 +2296,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = AST_standard_gauge_railway
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 5
@@ -2464,7 +2473,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = AST_standard_gauge_railway
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 1
@@ -2517,7 +2526,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = AST_standard_gauge_railway
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 1
@@ -2666,7 +2675,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = AST_establish_advisory_war_council
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 10
@@ -2700,7 +2709,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = AST_establish_advisory_war_council
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 5
@@ -2934,7 +2943,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = AST_establish_advisory_war_council
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 15
@@ -2993,7 +3002,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = AST_establish_advisory_war_council
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 5
@@ -3181,7 +3190,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = AST_establish_advisory_war_council
 
-		cost = 10
+		cost = 5
 
 		ai_will_do = {
 			factor = 1
@@ -3621,7 +3630,7 @@ focus_tree = {
 		cost = 5
 
 		completion_reward = {
-			add_political_power = 50
+			add_political_power = 75
 			remove_ideas = AST_conscript_malus
 			add_autonomy_ratio = {
 				value = 0.25
@@ -3752,10 +3761,15 @@ focus = {
 		available_if_capitulated = yes
 
 		completion_reward = {
-			add_ideas = AST_Education	
+			add_ideas = AST_Education
+			AST = {
+  				modify_tech_sharing_bonus = {
+     				id = commonwealth_research
+     				bonus = 0.04
+			}
 		}
 	}
-	
+}	
 	focus = {
 		id = AST_Homeland_defence
 		icon = GFX_goal_generic_defence
@@ -3764,7 +3778,7 @@ focus = {
 		y = 3
 		relative_position_id = AST_Australia_First
 
-		cost = 10
+		cost = 7.2
 
 		ai_will_do = {
 			factor = 1
@@ -4022,7 +4036,7 @@ focus = {
 		}
 
 		available = {
-			has_war_with = JAP
+			has_war_with = ITA
 
 		}
 		


### PR DESCRIPTION
standardization of focus tree times in line with other nations.
nerfed tank side bonuses, reapplied mutual exclusive to first tank focus/SF focus
Gave SF branch 2 small doctrine bonuses
lowered consumer goods penalty from ideas from 5% to 3 % (old oak it was 1%).
Buffed Australia first path to try and make it more appealing. (need someone to show how to do tooltips to advertise which focuses provide which buttons. 