### PR TITLE
ship module requirements

### DIFF
--- a/common/units/equipment/ship_hull_cruiser.txt
+++ b/common/units/equipment/ship_hull_cruiser.txt
@@ -40,7 +40,7 @@ equipments = {
 				allowed_module_categories = { ship_cruiser_armor }
 			}
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_anti_air
@@ -52,7 +52,7 @@ equipments = {
 				}
 			}
 			mid_2_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_anti_air
@@ -163,7 +163,7 @@ equipments = {
 			fixed_ship_secondaries_slot = inherit
 			fixed_ship_armor_slot = inherit
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_light_battery
 					ship_medium_battery
@@ -171,7 +171,7 @@ equipments = {
 				}
 			}
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_anti_air
@@ -234,7 +234,7 @@ equipments = {
 			fixed_ship_secondaries_slot = inherit
 			fixed_ship_armor_slot = inherit
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_anti_air
 					ship_light_battery
@@ -242,7 +242,7 @@ equipments = {
 				}
 			}
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_anti_air
@@ -316,7 +316,7 @@ equipments = {
 			fixed_ship_secondaries_slot = inherit
 			fixed_ship_armor_slot = inherit
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_anti_air
 					ship_light_battery
@@ -324,7 +324,7 @@ equipments = {
 				}
 			}
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_anti_air

--- a/common/units/equipment/ship_hull_heavy.txt
+++ b/common/units/equipment/ship_hull_heavy.txt
@@ -46,14 +46,14 @@ equipments = {
 				allowed_module_categories = { ship_heavy_armor }
 			}
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_anti_air
 					ship_heavy_battery
 				}
 			}
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_anti_air
@@ -150,13 +150,13 @@ equipments = {
 			fixed_ship_secondaries_slot = inherit
 			fixed_ship_armor_slot = inherit
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_anti_air
 				}
 			}
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_anti_air
@@ -228,14 +228,14 @@ equipments = {
 				allowed_module_categories = { ship_heavy_armor }
 			}
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_anti_air
 					ship_heavy_battery
 				}
 			}
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_anti_air
 					ship_secondaries
@@ -298,13 +298,22 @@ equipments = {
 			fixed_ship_secondaries_slot = inherit
 			fixed_ship_armor_slot = inherit
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_anti_air
 					ship_heavy_battery
 				}
 			}
 			mid_1_custom_slot = {
+				required = yes
+				allowed_module_categories = {
+					ship_anti_air
+					ship_secondaries
+					ship_airplane_launcher
+					ship_heavy_battery
+				}
+			}
+			mid_2_custom_slot = {
 				required = no
 				allowed_module_categories = {
 					ship_anti_air
@@ -313,7 +322,6 @@ equipments = {
 					ship_heavy_battery
 				}
 			}
-			mid_2_custom_slot = mid_1_custom_slot
 			rear_1_custom_slot = {
 				required = no
 				allowed_module_categories = {
@@ -360,13 +368,22 @@ equipments = {
 			fixed_ship_secondaries_slot = inherit
 			fixed_ship_armor_slot = inherit
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_anti_air
 					ship_heavy_battery
 				}
 			}
 			mid_1_custom_slot = {
+				required = yes
+				allowed_module_categories = {
+					ship_anti_air
+					ship_secondaries
+					ship_airplane_launcher
+					ship_heavy_battery
+				}
+			}
+			mid_2_custom_slot = {
 				required = no
 				allowed_module_categories = {
 					ship_anti_air
@@ -375,8 +392,7 @@ equipments = {
 					ship_heavy_battery
 				}
 			}
-			mid_2_custom_slot = mid_1_custom_slot
-			mid_3_custom_slot = mid_1_custom_slot
+			mid_3_custom_slot = mid_2_custom_slot
 			rear_1_custom_slot = {
 				required = no
 				allowed_module_categories = {
@@ -423,13 +439,22 @@ equipments = {
 			fixed_ship_secondaries_slot = inherit
 			fixed_ship_armor_slot = inherit
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_anti_air
 					ship_heavy_battery
 				}
 			}
 			mid_1_custom_slot = {
+				required = yes
+				allowed_module_categories = {
+					ship_anti_air
+					ship_secondaries
+					ship_airplane_launcher
+					ship_heavy_battery
+				}
+			}
+			mid_2_custom_slot = {
 				required = no
 				allowed_module_categories = {
 					ship_anti_air
@@ -438,8 +463,7 @@ equipments = {
 					ship_heavy_battery
 				}
 			}
-			mid_2_custom_slot = mid_1_custom_slot
-			mid_3_custom_slot = mid_1_custom_slot
+			mid_3_custom_slot = mid_2_custom_slot
 			rear_1_custom_slot = {
 				required = no
 				allowed_module_categories = {

--- a/common/units/equipment/ship_hull_light.txt
+++ b/common/units/equipment/ship_hull_light.txt
@@ -44,7 +44,7 @@ equipments = {
 			}
 
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_anti_air
@@ -137,7 +137,7 @@ equipments = {
 			fixed_ship_engine_slot = inherit
 
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_depth_charge
@@ -182,7 +182,7 @@ equipments = {
 			fixed_ship_engine_slot = inherit
 
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_depth_charge
 					ship_anti_air
@@ -190,7 +190,7 @@ equipments = {
 				}
 			}
 			mid_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_torpedo
 					ship_depth_charge
@@ -245,7 +245,7 @@ equipments = {
 			fixed_ship_torpedo_slot = inherit
 			fixed_ship_engine_slot = inherit
 			front_1_custom_slot = {
-				required = no
+				required = yes
 				allowed_module_categories = {
 					ship_depth_charge
 					ship_anti_air
@@ -253,6 +253,15 @@ equipments = {
 				}
 			}
 			mid_1_custom_slot = {
+				required = yes
+				allowed_module_categories = {
+					ship_torpedo
+					ship_depth_charge
+					ship_anti_air
+					ship_light_battery
+				}
+			}
+			mid_2_custom_slot = {
 				required = no
 				allowed_module_categories = {
 					ship_torpedo
@@ -261,7 +270,6 @@ equipments = {
 					ship_light_battery
 				}
 			}
-			mid_2_custom_slot = mid_1_custom_slot
 			rear_1_custom_slot = {
 				required = no
 				allowed_module_categories = {


### PR DESCRIPTION
destroyers, lights, and heavy hulls all require 2 mods, 1 battery.

Gets rid of ability to create empty ships - but should still allow for refitting possibilities for those that want to do so.

EDIT: Errors are still on this PR concerning existing hulls at start of game.