### PR TITLE
italian africa focuses time reduction

### DIFF
--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -1575,7 +1575,7 @@ focus_tree = {
 		prerequisite = { focus = ITA_victoryinETH }
 		x = 26 
 		y = 3
-		cost = 5
+		cost = 4
 		ai_will_do = {
 			factor = 10
 		}
@@ -2278,7 +2278,7 @@ focus_tree = {
 		prerequisite = { focus = ITA_spirito_fascista }
 		x = 27
 		y = 6
-		cost = 5
+		cost = 4
 		ai_will_do = {
 			factor = 10
 		}
@@ -2322,7 +2322,7 @@ focus_tree = {
 		prerequisite = { focus = ITA_immigration_ethiopia }
 		x = 27
 		y = 7
-		cost = 5
+		cost = 4
 		ai_will_do = {
 			factor = 10
 		}
@@ -2408,7 +2408,7 @@ focus_tree = {
 		prerequisite = { focus = ITA_Pursue_oil_autarchy }
 		x = 25
 		y = 6
-		cost = 5
+		cost = 4
 		ai_will_do = {
 			factor = 1
 		}
@@ -2489,7 +2489,7 @@ focus_tree = {
 		prerequisite = { focus = ITA_libyan_infrastructure }
 		x = 25
 		y = 7
-		cost = 5
+		cost = 4
 		ai_will_do = {
 			factor = 10
 		}


### PR DESCRIPTION
Talked with intrepid about this, lots of focus time on italy is needed to do a good navy air or army, so getting the african infrastructure is too hard to fit in and it would help prepare if it was just a little bit shorter.