### PR TITLE
BC speed and visibility nerf / light battery buffs

### DIFF
--- a/common/technologies/MTG_naval.txt
+++ b/common/technologies/MTG_naval.txt
@@ -1633,7 +1633,7 @@ early_ship_hull_carrier = {
 		start_year = 1940
 
 		
-		naval_torpedo_reveal_chance_factor = -0.05
+		naval_torpedo_reveal_chance_factor = -0.25
 		
 
 		folder = {

--- a/common/units/equipment/modules/00_ship_modules.txt
+++ b/common/units/equipment/modules/00_ship_modules.txt
@@ -14,14 +14,14 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 
 		add_stats = {
-			lg_attack = 1
+			lg_attack = 1.5
 			build_cost_ic = 90
 		}
 		multiply_stats = {
 			naval_speed = -0.01
 		}
 		add_average_stats = {
-			lg_armor_piercing = 1
+			lg_armor_piercing = 2.0
 		}
 
 		can_convert_from = {
@@ -38,7 +38,7 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 
 		add_stats = {
-			lg_attack = 1.5
+			lg_attack = 3.0
 			build_cost_ic = 120
 
 		}
@@ -46,7 +46,7 @@ equipment_modules = {
 			naval_speed = -0.01
 		}
 		add_average_stats = {
-			lg_armor_piercing = 2
+			lg_armor_piercing = 2.5
 		}
 
 		can_convert_from = {
@@ -67,12 +67,12 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 
 		add_stats = {
-			lg_attack = 2
+			lg_attack = 4.5
 			build_cost_ic = 150
 		}
 
 		add_average_stats = {
-			lg_armor_piercing = 2.5
+			lg_armor_piercing = 3.0
 		}
 		multiply_stats = {
 			naval_speed = -0.01
@@ -95,7 +95,7 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 
 		add_stats = {
-			lg_attack = 3.0
+			lg_attack = 6.0
 			build_cost_ic = 175
 		}
 		build_cost_resources = {
@@ -105,7 +105,7 @@ equipment_modules = {
 			naval_speed = -0.02
 		}
 		add_average_stats = {
-			lg_armor_piercing = 2.5
+			lg_armor_piercing = 3.5
 		}
 
 		can_convert_from = {
@@ -125,7 +125,7 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 
 		add_stats = {
-			lg_attack = 3
+			lg_attack = 3.5
 			anti_air_attack = 3
 			build_cost_ic = 300
 		}
@@ -136,7 +136,7 @@ equipment_modules = {
 			steel = 1
 		}
 		add_average_stats = {
-			lg_armor_piercing = 2.0
+			lg_armor_piercing = 2.5
 		}
 
 		can_convert_from = {
@@ -1511,7 +1511,7 @@ equipment_modules = {
 
 
 		add_stats = {
-			torpedo_attack = 14
+			torpedo_attack = 20
 			build_cost_ic = 90
 		}
 		multiply_stats = {
@@ -1530,7 +1530,7 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 
 		add_stats = {
-			torpedo_attack = 24
+			torpedo_attack = 30
 			naval_torpedo_hit_chance_factor = 0.02
 			build_cost_ic = 120
 		}
@@ -1563,7 +1563,7 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 
 		add_stats = {
-			torpedo_attack = 30
+			torpedo_attack = 35
 			naval_torpedo_hit_chance_factor = 0.035
 			build_cost_ic = 150
 		}
@@ -1586,7 +1586,7 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 
 		add_stats = {
-			torpedo_attack = 36
+			torpedo_attack = 40
 			naval_torpedo_hit_chance_factor = 0.05
 			build_cost_ic = 180
 		}
@@ -1951,13 +1951,13 @@ equipment_modules = {
 
 		multiply_stats = {
 			build_cost_ic = 0.075
-			naval_speed = -0.1
+			naval_speed = -0.15
 			max_strength = 0.03
 		}
 
 		add_stats = {
 			armor_value = 20
-			surface_visibility = 7
+			surface_visibility = 8
 			surface_detection = 8
 		}
 		dismantle_cost_ic = 4500
@@ -1988,7 +1988,7 @@ equipment_modules = {
 
 		multiply_stats = {
 			build_cost_ic = 0.075
-			naval_speed = -0.1
+			naval_speed = -0.15
 			max_strength = 0.08
 		}
 		build_cost_resources = {
@@ -1996,7 +1996,7 @@ equipment_modules = {
 		}
 		add_stats = {
 			armor_value = 25
-			surface_visibility = 7
+			surface_visibility = 8
 			surface_detection = 12
 		}
 		dismantle_cost_ic = 5500
@@ -2027,7 +2027,7 @@ equipment_modules = {
 
 		multiply_stats = {
 			build_cost_ic = 0.075
-			naval_speed = -0.1
+			naval_speed = -0.15
 			max_strength = 0.12
 		}
 		build_cost_resources = {
@@ -2036,7 +2036,7 @@ equipment_modules = {
 		}
 		add_stats = {
 			armor_value = 30
-			surface_visibility = 7
+			surface_visibility = 8
 			surface_detection = 16
 		}
 		dismantle_cost_ic = 6200


### PR DESCRIPTION
BC still outperforming torps build, suggest nerfing the speed and visbility so they get hit more easily and will make them weaker vs BB. Buffing torpedos they still suck despite the buffs given.