### PR TITLE
assault gun machine tools GER and trade interdiction

### DIFF
--- a/common/technologies/GER_armor.txt
+++ b/common/technologies/GER_armor.txt
@@ -1227,7 +1227,7 @@ technologies = {
 			position = { x = 6 y = @1942 }
 		}
 		dependencies = {
-			modern_tools = 1
+			assembly_line_production = 1
 		}		
 		ai_will_do = {
 			factor = 0

--- a/common/technologies/naval_doctrine.txt
+++ b/common/technologies/naval_doctrine.txt
@@ -1191,7 +1191,7 @@ technologies = {
 		# EFFECT ##############
 		battle_cruiser = {
 			max_organisation = 20
-			surface_visibility = -0.2
+			surface_visibility = -0.075
 			max_strength = -0.1
 			hg_attack = -0.1
 			anti_air_attack = -0.1
@@ -1201,7 +1201,7 @@ technologies = {
 
 		battleship = {
 			max_organisation = 20
-			surface_visibility = -0.2
+			surface_visibility = -0.075
 			max_strength = -0.1
 			hg_attack = -0.1
 			anti_air_attack = -0.1

--- a/history/states/799-Hatay.txt
+++ b/history/states/799-Hatay.txt
@@ -9,7 +9,7 @@ state={
 	state_category = enclave
 
 	history= {
-		owner = FRA
+		owner = TUR
 		add_core_of = TUR
 		add_core_of = SYR
 		victory_points = {


### PR DESCRIPTION
1941 assault guns require 1943 machine tools for some reason when 1943 does as well.

Nerfed trade interdiction visibility. 