### PR TITLE
Tank variant changes

### DIFF
--- a/common/units/equipment/tank_medium.txt
+++ b/common/units/equipment/tank_medium.txt
@@ -1102,7 +1102,7 @@ equipments = {
 		armor_value = 35
 
 		#Offensive Abilities
-		soft_attack = 20
+		soft_attack = 22
 		hard_attack = 8
 		ap_attack = 28
 		air_attack = 0 
@@ -1133,14 +1133,14 @@ equipments = {
 		reliability = 0.72
 
 		#Defensive Abilities
-		defense = 25
+		defense = 24
 		breakthrough = 16
 		armor_value = 52
 
 		#Offensive Abilities
-		soft_attack = 25
+		soft_attack = 27
 		hard_attack = 10
-		ap_attack = 52
+		ap_attack = 50
 		fuel_consumption = 3.4	
 		build_cost_ic = 32
 	}
@@ -1159,14 +1159,14 @@ equipments = {
 		reliability = 0.8
 
 		#Defensive Abilities
-		defense = 27
+		defense = 26
 		breakthrough = 18
 		armor_value = 62
 
 		#Offensive Abilities
-		soft_attack = 30
+		soft_attack = 32
 		hard_attack = 13
-		ap_attack = 62
+		ap_attack = 60
 		fuel_consumption = 3.6	
 		build_cost_ic = 34
 	}
@@ -1184,13 +1184,13 @@ equipments = {
 		maximum_speed = 6.6
 		reliability = 0.76
 		
-		defense = 29
+		defense = 28
 		breakthrough = 20
 		armor_value = 72	
 		
-		soft_attack = 35
+		soft_attack = 37
 		hard_attack = 16
-		ap_attack = 72
+		ap_attack = 70
 		
 		fuel_consumption = 3.8	
 	    build_cost_ic = 36

--- a/common/units/equipment/x_tank_chassis.txt
+++ b/common/units/equipment/x_tank_chassis.txt
@@ -464,7 +464,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 6
-		breakthrough = 3.6
+		breakthrough = 16
 		armor_value = 24.3
 		hardness = 0.55
 		
@@ -502,7 +502,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 7
-		breakthrough = 4.2
+		breakthrough = 19
 		armor_value = 30.6
 
 		#Offensive Abilities
@@ -537,7 +537,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 7.5
-		breakthrough = 4.5
+		breakthrough = 20
 		armor_value = 33.75
 
 		#Offensive Abilities
@@ -572,7 +572,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 8
-		breakthrough = 4.8
+		breakthrough = 22
 		armor_value = 36.9
 
 		#Offensive Abilities
@@ -607,7 +607,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 9
-		breakthrough = 5.4
+		breakthrough = 25
 		armor_value = 43.2
 
 		#Offensive Abilities
@@ -646,8 +646,8 @@ equipments = {
 		reliability = 0.72
 
 		#Defensive Abilities
-		defense = 2.6
-		breakthrough = 1.8
+		defense = 6
+		breakthrough = 16
 		armor_value = 27
 		hardness = 0.6
 
@@ -682,8 +682,8 @@ equipments = {
 		reliability = 0.74
 		fuel_consumption = 1.7	
 		#Defensive Abilities
-		defense = 3.4
-		breakthrough = 2.1
+		defense = 7
+		breakthrough = 19
 		armor_value = 34
 
 		#Offensive Abilities
@@ -716,8 +716,8 @@ equipments = {
 		reliability = 0.75
 		fuel_consumption = 1.7	
 		#Defensive Abilities
-		defense = 3.8
-		breakthrough = 2.25
+		defense = 7.5
+		breakthrough = 20
 		armor_value = 37.5
 
 		#Offensive Abilities
@@ -750,8 +750,8 @@ equipments = {
 		reliability = 0.76
 		fuel_consumption = 1.8
 		#Defensive Abilities
-		defense = 4.2
-		breakthrough = 2.4
+		defense = 8
+		breakthrough = 22
 		armor_value = 41
 
 		#Offensive Abilities
@@ -786,8 +786,8 @@ equipments = {
 		reliability = 0.78
 
 		#Defensive Abilities
-		defense = 5
-		breakthrough = 2.7
+		defense = 9
+		breakthrough = 25
 		armor_value = 48
 
 		#Offensive Abilities
@@ -828,16 +828,16 @@ equipments = {
 		reliability = 0.72
 
 		#Defensive Abilities
-		defense = 3.8
-		breakthrough = 3.4
+		defense = 6
+		breakthrough = 12
 		armor_value = 24.3
 		hardness = 0.55
 
 		#Offensive Abilities
 		soft_attack = 6
 		hard_attack = 2.8
-		ap_attack = 23
-		air_attack = 24
+		ap_attack = 25
+		air_attack = 26
 
 		#Space taken in convoy
 		lend_lease_cost = 8
@@ -866,15 +866,15 @@ equipments = {
 		reliability = 0.74
 
 		#Defensive Abilities
-		defense = 3.8
-		breakthrough = 3.8
+		defense = 7
+		breakthrough = 16
 		armor_value = 30.6
 
 		#Offensive Abilities
 		soft_attack = 7 
 		hard_attack = 3.6
-		ap_attack = 29
-		air_attack = 26 
+		ap_attack = 27
+		air_attack = 28
 
 		#space taken in convoy
 		lend_lease_cost = 8
@@ -902,14 +902,14 @@ equipments = {
 		reliability = 0.75
 
 		#Defensive Abilities
-		defense = 4
-		breakthrough = 4
+		defense = 7.5
+		breakthrough = 18
 		armor_value = 33.75
 		#Offensive Abilities
 		soft_attack = 7.5
 		hard_attack = 4
-		ap_attack = 32
-		air_attack = 27	
+		ap_attack = 30
+		air_attack = 29	
 
 		#space taken in convoy
 		lend_lease_cost = 8
@@ -935,15 +935,15 @@ equipments = {
 		#Misc Abilities
 		maximum_speed = 9.4
 		reliability = 0.76
-	     defense = 4.2
-		breakthrough = 4.2
+	     defense = 8
+		breakthrough = 20
 		armor_value = 36.9
 
 		#Offensive Abilities
 		soft_attack = 8
 		hard_attack = 4.4 
-		ap_attack = 35
-		air_attack = 28
+		ap_attack = 34
+		air_attack = 30
 
 		#space taken in convoy
 		lend_lease_cost = 8
@@ -973,15 +973,15 @@ equipments = {
 		reliability = 0.78
 
 		#Defensive Abilities
-		defense = 4.6
-		breakthrough = 4.6
+		defense = 9
+		breakthrough = 22
 		armor_value = 43.2
 
 		#Offensive Abilities
 		soft_attack = 9
 		hard_attack = 5.2
-		ap_attack = 41
-		air_attack = 30
+		ap_attack = 42
+		air_attack = 32
 
 		#space taken in convoy
 		lend_lease_cost = 8
@@ -1023,7 +1023,7 @@ equipments = {
 		armor_value = 45
 
 		#Offensive Abilities
-		soft_attack = 20
+		soft_attack = 21
 		hard_attack = 12
 		ap_attack = 49
 		air_attack = 0
@@ -1059,7 +1059,7 @@ equipments = {
 		armor_value = 50
 
 		#Offensive Abilities
-		soft_attack = 22
+		soft_attack = 23
 		hard_attack = 14
 		ap_attack = 54
 		fuel_consumption = 3.7	
@@ -1089,7 +1089,7 @@ equipments = {
 		armor_value = 55
 
 		#Offensive Abilities
-		soft_attack = 24
+		soft_attack = 25
 		hard_attack = 16
 		ap_attack = 59
 		fuel_consumption = 3.8	
@@ -1120,7 +1120,7 @@ equipments = {
 		armor_value = 60
 
 		#Offensive Abilities
-		soft_attack = 26
+		soft_attack = 27
 		hard_attack = 18
 		ap_attack = 64
 		fuel_consumption = 3.9	
@@ -1151,7 +1151,7 @@ equipments = {
 		armor_value = 65
 
 		#Offensive Abilities
-		soft_attack = 28
+		soft_attack = 29
 		hard_attack = 20
 		ap_attack = 69
 		fuel_consumption = 4.0	
@@ -1183,7 +1183,7 @@ equipments = {
 		armor_value = 70
 
 		#Offensive Abilities
-		soft_attack = 30
+		soft_attack = 31
 		hard_attack = 22
 		ap_attack = 74
 		fuel_consumption = 4.1	
@@ -1209,7 +1209,7 @@ equipments = {
 		breakthrough = 46
 		armor_value = 75
 		fuel_consumption = 4.2	
-		soft_attack = 32
+		soft_attack = 33
 		hard_attack = 24
 		ap_attack = 79
 	    build_cost_ic = 36
@@ -1241,7 +1241,7 @@ equipments = {
 		fuel_consumption = 4.3	
 		#Offensive Abilities
 
-		soft_attack = 34
+		soft_attack = 35
 		hard_attack = 26
 		ap_attack = 84
 		
@@ -1273,7 +1273,7 @@ equipments = {
 		armor_value = 85
 		#Offensive Abilities
 	
-		soft_attack = 36
+		soft_attack = 37
 		hard_attack = 28
 		ap_attack = 89
 		
@@ -1306,7 +1306,7 @@ equipments = {
 
 		#Offensive Abilities
 
-		soft_attack = 38
+		soft_attack = 39
 		hard_attack = 30
 		ap_attack = 94
 		
@@ -1335,7 +1335,7 @@ equipments = {
 		breakthrough = 50
 		armor_value = 95
 
-		soft_attack = 34
+		soft_attack = 35
 		hard_attack = 26
 		ap_attack = 99
 	    build_cost_ic = 42
@@ -1364,7 +1364,7 @@ equipments = {
 		breakthrough = 54
 		armor_value = 100
 
-		soft_attack = 38
+		soft_attack = 39
 		hard_attack = 30
 		ap_attack = 104
 	    build_cost_ic = 44
@@ -1392,7 +1392,7 @@ equipments = {
 		breakthrough = 50
 		armor_value = 75
 
-		soft_attack = 38
+		soft_attack = 39
 		hard_attack = 24
 		ap_attack = 79
 	    build_cost_ic = 38
@@ -1427,7 +1427,7 @@ equipments = {
 		#Defensive Abilities
 		fuel_consumption = 2.5	
 		defense = 10
-		breakthrough = 5.6
+		breakthrough = 19
 		hardness = 0.75
 		armor_value = 49
 
@@ -1464,7 +1464,7 @@ equipments = {
 		#Defensive Abilities
 
 		defense = 10.5
-		breakthrough = 5.9
+		breakthrough = 20
 		
 		armor_value = 54
 
@@ -1501,7 +1501,7 @@ equipments = {
 		#Defensive Abilities
 
 		defense = 11
-		breakthrough = 6.2
+		breakthrough = 21
 		
 		armor_value = 58
 
@@ -1536,7 +1536,7 @@ equipments = {
 		fuel_consumption = 2.7	
 		#Defensive Abilities
 		defense = 11.5
-		breakthrough = 6.5
+		breakthrough = 22
 		
 		armor_value = 63
 
@@ -1571,7 +1571,7 @@ equipments = {
 		#Defensive Abilities
 
 		defense = 12
-		breakthrough = 6.8
+		breakthrough = 23
 		
 		armor_value = 67
 
@@ -1605,7 +1605,7 @@ equipments = {
 		fuel_consumption = 2.8	
 		#Defensive Abilities
 		defense = 12.5
-		breakthrough = 7.1
+		breakthrough = 24
 		
 		armor_value = 72
 
@@ -1637,7 +1637,7 @@ equipments = {
 		fuel_consumption = 2.8	
 		#Defensive Abilities
 		defense = 12.5
-		breakthrough = 7.1
+		breakthrough = 24
 		
 		armor_value = 72
 
@@ -1671,7 +1671,7 @@ equipments = {
 		#Defensive Abilities
 
 		defense = 13
-		breakthrough = 7.4
+		breakthrough = 25
 		
 		armor_value = 76
 
@@ -1712,7 +1712,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 10
-		breakthrough = 5.6
+		breakthrough = 19
 		hardness = 0.8
 		armor_value = 55
 
@@ -1748,7 +1748,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 10.5
-		breakthrough = 5.9
+		breakthrough = 20
 		fuel_consumption = 2.6	
 		armor_value = 60
 
@@ -1783,7 +1783,7 @@ equipments = {
 		fuel_consumption = 2.7	
 		#Defensive Abilities
 		defense = 11
-		breakthrough = 6.2
+		breakthrough = 21
 		
 		armor_value = 70
 
@@ -1818,7 +1818,7 @@ equipments = {
 		fuel_consumption = 2.7	
 		#Defensive Abilities
 		defense = 11.5
-		breakthrough = 6.5
+		breakthrough = 22
 		
 		armor_value = 70
 
@@ -1853,7 +1853,7 @@ equipments = {
 		fuel_consumption = 2.8	
 		#Defensive Abilities
 		defense = 12
-		breakthrough = 6.8
+		breakthrough = 23
 		
 		armor_value = 75
 
@@ -1888,7 +1888,7 @@ equipments = {
 		fuel_consumption = 2.8	
 		#Defensive Abilities
 		defense = 12.5
-		breakthrough = 7.1
+		breakthrough = 24
 		
 		armor_value = 80
 
@@ -1923,7 +1923,7 @@ equipments = {
 		fuel_consumption = 2.8	
 		#Defensive Abilities
 		defense = 13
-		breakthrough = 7.4
+		breakthrough = 24
 		
 		armor_value = 80
 
@@ -1958,7 +1958,7 @@ equipments = {
 		fuel_consumption = 2.9	
 		#Defensive Abilities
 		defense = 13.5
-		breakthrough = 7.7
+		breakthrough = 25
 		
 		armor_value = 70
 
@@ -1999,14 +1999,14 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 4.4
-		breakthrough = 4.4
+		breakthrough = 17
 		hardness = 0.75
 		fuel_consumption = 1.9		
 		armor_value = 49
 
 		#Offensive Abilities
 		soft_attack = 10
-		air_attack = 26
+		air_attack = 28
 		hard_attack = 4.8
 		ap_attack = 47
 
@@ -2036,7 +2036,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 4.6
-		breakthrough = 4.6
+		breakthrough = 18
 		fuel_consumption = 1.9		
 		armor_value = 54
 
@@ -2046,7 +2046,7 @@ equipments = {
 		hard_attack = 5.2
 		ap_attack = 51
 
-		air_attack = 27
+		air_attack = 29
 		lend_lease_cost = 10
 
 		resources = {
@@ -2073,7 +2073,7 @@ equipments = {
 		fuel_consumption = 2.0		
 		#Defensive Abilities
 		defense = 4.8
-		breakthrough = 4.8
+		breakthrough = 19
 		
 		armor_value = 58
 
@@ -2082,7 +2082,7 @@ equipments = {
 
 		hard_attack = 5.6
 		ap_attack = 55
-		air_attack = 28
+		air_attack = 30
 		lend_lease_cost = 10
 
 		resources = {
@@ -2109,7 +2109,7 @@ equipments = {
 		fuel_consumption = 2.0	
 		#Defensive Abilities
 		defense = 5
-		breakthrough = 5
+		breakthrough = 20
 		
 		armor_value = 63
 
@@ -2118,7 +2118,7 @@ equipments = {
 
 		hard_attack = 6
 		ap_attack = 59
-		air_attack = 29
+		air_attack = 31
 		lend_lease_cost = 10
 
 		resources = {
@@ -2145,7 +2145,7 @@ equipments = {
 		fuel_consumption = 2.1	
 		#Defensive Abilities
 		defense = 5.2
-		breakthrough = 5.2
+		breakthrough = 21
 		
 		armor_value = 67
 
@@ -2154,7 +2154,7 @@ equipments = {
 
 		hard_attack = 6.4
 		ap_attack = 63
-		air_attack = 30
+		air_attack = 32
 		lend_lease_cost = 10
 
 		resources = {
@@ -2181,7 +2181,7 @@ equipments = {
 		fuel_consumption = 2.1	
 		#Defensive Abilities
 		defense = 5.4
-		breakthrough = 5.4
+		breakthrough = 22
 		
 		armor_value = 72
 
@@ -2189,6 +2189,7 @@ equipments = {
 		soft_attack = 12.5
 		hard_attack = 6.8
 		ap_attack = 67
+		air_attack = 33
 		lend_lease_cost = 10
 
 		resources = {
@@ -2197,7 +2198,6 @@ equipments = {
 			chromium = 1
 		}
 
-		air_attack = 31
 		
 		build_cost_ic = 35
 	}
@@ -2217,7 +2217,7 @@ equipments = {
 		fuel_consumption = 2.1	
 		#Defensive Abilities
 		defense = 5.4
-		breakthrough = 5.4
+		breakthrough = 22
 		
 		armor_value = 72
 
@@ -2225,6 +2225,7 @@ equipments = {
 		soft_attack = 12.5
 		hard_attack = 6.8
 		ap_attack = 67
+		air_attack = 33
 		lend_lease_cost = 10
 
 		resources = {
@@ -2233,7 +2234,6 @@ equipments = {
 			chromium = 1
 		}
 
-		air_attack = 31
 		
 		build_cost_ic = 36		
 	}
@@ -2253,7 +2253,7 @@ equipments = {
 		fuel_consumption = 2.2	
 		#Defensive Abilities
 		defense = 5.6
-		breakthrough = 5.6
+		breakthrough = 23
 		
 		armor_value = 76
 
@@ -2262,7 +2262,7 @@ equipments = {
 
 		hard_attack = 7.2
 		ap_attack = 71
-		air_attack = 32
+		air_attack = 34
 		lend_lease_cost = 10
 
 		resources = {
@@ -2598,7 +2598,7 @@ equipments = {
 		fuel_consumption = 3.2
 		#Defensive Abilities
 		defense = 18.5
-		breakthrough = 7.9
+		breakthrough = 32
 		hardness = 0.8
 		armor_value = 78.3
 
@@ -2634,7 +2634,7 @@ equipments = {
 		fuel_consumption = 3.3
 		#Defensive Abilities
 		defense = 19.5
-		breakthrough = 8.5
+		breakthrough = 36
 		
 		armor_value = 87
 
@@ -2667,7 +2667,7 @@ equipments = {
 		fuel_consumption = 3.4
 		#Defensive Abilities
 		defense = 20
-		breakthrough = 8.8
+		breakthrough = 38
 		armor_value = 91.8
 
 		#Offensive Abilities
@@ -2702,7 +2702,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 20.5
-		breakthrough = 9.1
+		breakthrough = 40
 		armor_value = 96
 		
 
@@ -2737,7 +2737,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 21
-		breakthrough = 9.4
+		breakthrough = 42
 		armor_value = 101
 
 		#Offensive Abilities
@@ -2772,7 +2772,7 @@ equipments = {
 
 		#Defensive Abilities
 		defense = 21.5
-		breakthrough = 9.7
+		breakthrough = 44
 		armor_value = 105
 		
 
@@ -2813,8 +2813,8 @@ equipments = {
 		reliability = 0.63
 		fuel_consumption = 3.2
 		#Defensive Abilities
-		defense = 5
-		breakthrough = 3.95
+		defense = 9
+		breakthrough = 32
 		hardness = 0.9
 		armor_value = 87
 
@@ -2849,8 +2849,8 @@ equipments = {
 		reliability = 0.65
 		fuel_consumption = 3.3
 		#Defensive Abilities
-		defense = 5.8
-		breakthrough = 4.25
+		defense = 10
+		breakthrough = 36
 		
 		armor_value = 97
 
@@ -2882,8 +2882,8 @@ equipments = {
 		reliability = 0.66
 		fuel_consumption = 3.4
 		#Defensive Abilities
-		defense = 6.2
-		breakthrough = 4.4
+		defense = 10.5
+		breakthrough = 38
 		armor_value = 102
 
 		#Offensive Abilities
@@ -2918,8 +2918,8 @@ equipments = {
 		reliability = 0.67
 		fuel_consumption = 3.5
 		#Defensive Abilities
-		defense = 6.6
-		breakthrough = 4.5
+		defense = 11
+		breakthrough = 40
 		armor_value = 107
 
 		#Offensive Abilities
@@ -2953,8 +2953,8 @@ equipments = {
 		reliability = 0.68
 		fuel_consumption = 3.6
 		#Defensive Abilities
-		defense = 7
-		breakthrough = 4.7
+		defense = 11.5
+		breakthrough = 42
 		armor_value = 112
 
 		#Offensive Abilities
@@ -2990,8 +2990,8 @@ equipments = {
 		reliability = 0.69
 
 		#Defensive Abilities
-		defense = 7.4
-		breakthrough = 4.8
+		defense = 12
+		breakthrough = 44
 		armor_value = 117
 
 		#Offensive Abilities


### PR DESCRIPTION
Assault guns:
- increase 2 soft attack
- decrease 2 piercing
- decrease 1 defense

Light Tank SPGs/TDs
- now has half the regular light tank breakthrough. defense adjusted to match tank tech
Light Tank AA
- air attack buffed slighty (to be better than towed AA) piercing changed a bit

Medium Tanks:
- increase 1 soft attack
Medium Tank SPG/TDs:
- breakthrough is half of regular medium tank
Medium AA:
- increase 2 air attack
- breakthrough improved (but less than other variants)

Heavy Tank SPGs and TDs:
- breakthrough is now a little less than half regular tank
