### PR TITLE
Tank terrain and raj changes

### DIFF
--- a/common/decisions/instant_effects.txt
+++ b/common/decisions/instant_effects.txt
@@ -972,9 +972,6 @@ PAR_instant_effect_decisions = {
 				has_full_control_of_state = 640
 				has_full_control_of_state = 288
 				}
-				NOT = {
-				RAJ = { has_completed_focus = RAJ_princes_4 }
-				}
 			}
 		}
 

--- a/common/ideas/british_raj.txt
+++ b/common/ideas/british_raj.txt
@@ -301,7 +301,7 @@ ideas = {
 			removal_cost = -1
 
 			modifier = {
-				consumer_goods_factor = 0.01
+				consumer_goods_factor = 0.02
 				production_speed_arms_factory_factor = 0.15
 				production_speed_dockyard_factor = 0.075
 				min_export = -0.05

--- a/common/national_focus/india.txt
+++ b/common/national_focus/india.txt
@@ -1105,49 +1105,49 @@ focus_tree = {
 		}
 	}
 	
-	focus = {
-		id = RAJ_princes_famine
-		icon = GFX_RAJ_solve_famine_quickly
-		relative_position_id = RAJ_must_decide
-		prerequisite = { focus = RAJ_princes_5 }
-		x = 5
-		y = 7
-
-		cost = 7.145
-
-		ai_will_do = {
-			factor = 
-		}
-
-		available = {
-			IF ={
-				has_idea = RAJ_famine
-			}
-		}
-
-		bypass = {
-
-		}
-		
-		cancel_if_invalid = yes
-		continue_if_invalid = no
-		available_if_capitulated = yes
-
-		complete_tooltip = {
-			swap_ideas = {
-				remove_idea = RAJ_famine
-				add_idea = RAJ_famine_fix
-			}
-			
-		}
-
-		completion_reward = {
-			swap_ideas = {
-				remove_idea = RAJ_famine
-				add_idea = RAJ_famine_fix
-			}
-		}
-	}
+#	focus = {
+#		id = RAJ_princes_famine
+#		icon = GFX_RAJ_solve_famine_quickly
+#		relative_position_id = RAJ_must_decide
+#		prerequisite = { focus = RAJ_princes_5 }
+#		x = 5
+#		y = 7
+#
+#		cost = 7.145
+#
+#		ai_will_do = {
+#			factor = 
+#		}
+#
+#		available = {
+#			IF ={
+#				has_idea = RAJ_famine
+#			}
+#		}
+#
+#		bypass = {
+#
+#		}
+#		
+#		cancel_if_invalid = yes
+#		continue_if_invalid = no
+#		available_if_capitulated = yes
+#
+#		complete_tooltip = {
+#			swap_ideas = {
+#				remove_idea = RAJ_famine
+#				add_idea = RAJ_famine_fix
+#			}
+#			
+#		}
+#
+#		completion_reward = {
+#			swap_ideas = {
+#				remove_idea = RAJ_famine
+#				add_idea = RAJ_famine_fix
+#			}
+#		}
+#	}
 	
 	focus = {
 		id = RAJ_princes_6
@@ -6632,12 +6632,48 @@ focus_tree = {
 	}	
 
 	focus = {
-		id = RAJ_press_indians_into_the_dockyards_focus
-		icon = GFX_goal_generic_occupy_states_coastal
+		id = RAJ_a_merchant_feel
+		icon = GFX_goal_generic_build_navy
 		relative_position_id = RAJ_bengal_dockyards
 		prerequisite = { focus = RAJ_dockyard_construction_efforts }
+
 		x = 0
 		y = 2
+
+		cost = 5
+
+		ai_will_do = {
+			factor = 4
+		}
+
+		available = {
+		}
+
+		bypass = {
+
+		}
+
+		cancel_if_invalid = yes
+		continue_if_invalid = no
+		available_if_capitulated = yes
+
+		
+		complete_tooltip = {
+			add_ideas = RAJ_a_merchant_feel_idea
+		}
+		
+		completion_reward = {
+			add_ideas = RAJ_a_merchant_feel_idea
+		}
+	}
+	
+	focus = {
+		id = RAJ_press_indians_into_the_dockyards_focus
+		icon = GFX_goal_generic_occupy_states_coastal
+		relative_position_id = RAJ_a_merchant_feel
+		prerequisite = { focus = RAJ_a_merchant_feel }
+		x = 1
+		y = 1
 
 		cost = 5
 
@@ -6668,8 +6704,8 @@ focus_tree = {
 	focus = {
 		id = RAJ_aid_british_rnd
 		icon = GFX_focus_research
-		relative_position_id = RAJ_press_indians_into_the_dockyards_focus
-		prerequisite = { focus = RAJ_press_indians_into_the_dockyards_focus }
+		relative_position_id = RAJ_a_merchant_feel
+		prerequisite = { focus = RAJ_a_merchant_feel }
 
 		x = -1
 		y = 1
@@ -6692,42 +6728,11 @@ focus_tree = {
 		available_if_capitulated = yes
 
 		complete_tooltip = {
+			add_research_slot = 1 
 		}
 
 		completion_reward = {
 			add_research_slot = 1 
-		}
-	}
-	
-	focus = {
-		id = RAJ_a_merchant_feel
-		icon = GFX_goal_generic_build_navy
-		relative_position_id = RAJ_press_indians_into_the_dockyards_focus
-		prerequisite = { focus = RAJ_press_indians_into_the_dockyards_focus }
-
-		x = 1
-		y = 1
-
-		cost = 5
-
-		ai_will_do = {
-			factor = 4
-		}
-
-		available = {
-		}
-
-		bypass = {
-
-		}
-
-		cancel_if_invalid = yes
-		continue_if_invalid = no
-		available_if_capitulated = yes
-
-
-		completion_reward = {
-			add_ideas = RAJ_a_merchant_feel_idea
 		}
 	}
 	

--- a/common/national_focus/india.txt
+++ b/common/national_focus/india.txt
@@ -1297,42 +1297,42 @@ focus_tree = {
 		}
 	}
 	
-	focus = {
-		id = RAJ_quit_india_removed
-		icon = GFX_goal_generic_imprison_people
-		prerequisite = { focus = RAJ_make_use_of_the_muslim_league }
-		relative_position_id = RAJ_cripps_mission
-		x = 0
-		y = 2
-
-		cost = 2.9
-
-		ai_will_do = {
-			factor = 100
-		}
-		
-		available = {
-			IF = {
-				has_completed_focus = RAJ_princes_4
-			}
-		}
-		
-		bypass = {
-
-		}
-
-		cancel_if_invalid = yes
-		continue_if_invalid = no
-		available_if_capitulated = yes
-
-		complete_tooltip = {
-			remove_ideas = RAJ_quit_india_movement_3
-		}
-
-		completion_reward = {
-			remove_ideas = RAJ_quit_india_movement_3		
-		}
-	}
+#	focus = {
+#		id = RAJ_quit_india_removed
+#		icon = GFX_goal_generic_imprison_people
+#		prerequisite = { focus = RAJ_make_use_of_the_muslim_league }
+#		relative_position_id = RAJ_cripps_mission
+#		x = 0
+#		y = 2
+#
+#		cost = 2.9
+#
+#		ai_will_do = {
+#			factor = 100
+#		}
+#		
+#		available = {
+#			IF = {
+#				has_completed_focus = RAJ_princes_4
+#			}
+#		}
+#		
+#		bypass = {
+#
+#		}
+#
+#		cancel_if_invalid = yes
+#		continue_if_invalid = no
+#		available_if_capitulated = yes
+#
+#		complete_tooltip = {
+#			remove_ideas = RAJ_quit_india_movement_3
+#		}
+#
+#		completion_reward = {
+#			remove_ideas = RAJ_quit_india_movement_3		
+#		}
+#	}
 	
 	focus = {
 		id = RAJ_commit_to_africa
@@ -1681,7 +1681,7 @@ focus_tree = {
 			439 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					level = 2
+					level = 1
 					type = industrial_complex
 					instant_build = yes 
 				}
@@ -1708,7 +1708,7 @@ focus_tree = {
 			439 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					level = 2
+					level = 1
 					type = industrial_complex
 					instant_build = yes 
 				}
@@ -1754,7 +1754,7 @@ focus_tree = {
 			438 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					level = 2
+					level = 1
 					type = industrial_complex
 					instant_build = yes 
 				}
@@ -1779,7 +1779,7 @@ focus_tree = {
 			438 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					level = 2
+					level = 1
 					type = industrial_complex
 					instant_build = yes 
 				}
@@ -3941,7 +3941,7 @@ focus_tree = {
 			435 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					level = 2
+					level = 1
 					type = industrial_complex
 					instant_build = yes 
 				}
@@ -3952,7 +3952,7 @@ focus_tree = {
 			435 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					level = 2
+					level = 1
 					type = industrial_complex
 					instant_build = yes 
 				}
@@ -4041,7 +4041,7 @@ focus_tree = {
 			436 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					level = 2
+					level = 1
 					type = industrial_complex
 					instant_build = yes 
 				}
@@ -4052,7 +4052,7 @@ focus_tree = {
 			436 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					level = 2
+					level = 1
 					type = industrial_complex
 					instant_build = yes 
 				}
@@ -4320,14 +4320,6 @@ focus_tree = {
 					instant_build = yes 
 				}
 			}
-			435 = {
-				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = arms_factory
-					level = 2
-					instant_build = yes 
-				}
-			}
 			swap_ideas = {
 				remove_idea = RAJ_the_princes_takeover
 				add_idea = RAJ_the_princes_supply_war
@@ -4354,14 +4346,6 @@ focus_tree = {
 				}
 			}
 			436 = {
-				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = arms_factory
-					level = 2
-					instant_build = yes 
-				}
-			}
-			435 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory

--- a/common/units/heavy_armor.txt
+++ b/common/units/heavy_armor.txt
@@ -37,13 +37,13 @@ sub_units = {
 				
 		forest = {
 		    attack = -0.3
-			defence = -0.15
+			defence = -0.2
 			movement = -0.25
 		}
 		hills = {
-		    attack = -0.35
+		    attack = -0.3
 			defence = -0.2
-			movement = -0.25
+			movement = -0.2
 		}
 		mountain = 	{
 		    attack = -0.5
@@ -61,12 +61,12 @@ sub_units = {
 			movement = -0.5
 		}
 		urban = {
-			attack = -0.4
+			attack = -0.3
 			defence = -0.2
 			movement = 0.05
 		}
 		river = { 
-			attack = -0.4
+			attack = -0.3
 			defence = -0.2
 			movement = -0.4
 		}

--- a/common/units/medium_armor.txt
+++ b/common/units/medium_armor.txt
@@ -38,14 +38,14 @@ sub_units = {
 		#soft_attack = 0.5
 		
 		forest = {
-		    attack = -0.25
-			defence = -0.15
+		    attack = -0.2
+			defence = -0.2
 			movement = -0.2
 		}
 		hills = 	{
-		    attack = -0.3
-			defence = -0.2
-			movement = -0.2
+		    attack = -0.2
+			defence = -0.15
+			movement = -0.1
 		}
 		mountain = 	{
 		    attack = -0.4
@@ -53,24 +53,24 @@ sub_units = {
 			movement = -0.4
 		}
 		jungle = {
-		    attack = -0.4
+		    attack = -0.3
 			defence = -0.3
 			movement = -0.4
 		}
 		marsh = {
-		    attack = -0.4 
+		    attack = -0.4
 			defence = -0.3
 			movement = -0.5
 		}
 		urban = {
-			attack = -0.3
+			attack = -0.25
 			defence = -0.2
 			movement = 0.05
 		}
 		river = { 
-			attack = -0.2
+			attack = -0.25
 			defence = -0.1
-			movement = -0.2
+			movement = -0.3
 		}
 		amphibious = { 
 			attack = -5.0

--- a/common/units/sp_artillery_brigade.txt
+++ b/common/units/sp_artillery_brigade.txt
@@ -119,14 +119,14 @@ sub_units = {
 		suppression = 2
 
 		forest = {
-		    attack = -0.2
-			defence = -0.15
+		    attack = -0.12
+			defence = -0.2
 			movement = -0.2
 		}
 		hills = 	{
-		    attack = -0.25
-			defence = -0.2
-			movement = -0.2
+		    attack = -0.12
+			defence = -0.15
+			movement = -0.1
 		}
 		mountain = 	{
 		    attack = -0.4
@@ -134,30 +134,27 @@ sub_units = {
 			movement = -0.4
 		}
 		jungle = {
-		    attack = -0.4
+		    attack = -0.25
 			defence = -0.3
 			movement = -0.4
 		}
 		marsh = {
-		    attack = -0.4 
+		    attack = -0.4
 			defence = -0.3
 			movement = -0.5
 		}
 		urban = {
-			attack = -0.2
+			attack = -0.10
 			defence = -0.2
 			movement = 0.05
 		}
 		river = { 
-			attack = -0.2
+			attack = -0.25
 			defence = -0.1
-			movement = -0.2
+			movement = -0.3
 		}
 		amphibious = { 
 			attack = -5.0
-		}
-		fort = {
-			attack = 0.2
 		}
 		plains = {
 			attack = 0.05
@@ -168,6 +165,9 @@ sub_units = {
 			attack = 0.05
 			defence = 0.0 
 			movement = 0.05
+		}
+		fort = {
+			attack = 0.2
 		}
 	}
 	
@@ -340,41 +340,51 @@ sub_units = {
 		suppression = 2
 		
 		forest = {
-		    attack = -0.3
-			movement = -0.4
+		    attack = -0.1
+			defence = -0.2
+			movement = -0.1
 		}
 		hills = 	{
-		    attack = -0.1
+		    attack = -0.2
+			defence = -0.15
 		}
 		mountain = 	{
-		    attack = -0.2
+		    attack = -0.4
+			defence = -0.3
+			movement = -0.2
 		}
 		jungle = {
-		    attack = -0.4
-			movement = -0.4
+		    attack = -0.2
+			defence = -0.3
+			movement = -0.2
 		}
 		marsh = {
-		    attack = -0.4 
-			movement = -0.5
+		    attack = -0.3
+			defence = -0.3
+			movement = -0.3
 		}
 		urban = {
-			attack = -0.4
-			defence = -0.1		 
+			attack = -0.15
+			defence = -0.1
+			movement = 0.05
 		}
 		river = { 
-			attack = -0.2 
+			attack = -0.25
+			defence = -0.1
 			movement = -0.2
 		}
 		amphibious = { 
-			attack = -0.7
+			attack = -5.0
 		}
 		plains = {
-			attack = 0.0
-			movement = 0.05 
+			attack = 0.00
+			defence = 0.0 
+			movement = 0.05
 		}
         desert = {
-			attack = 0.0
-			movement = 0.05 
+			attack = 0.00
+			defence = 0.0 
+			movement = 0.05
 		}
 		fort = {
 			attack = 0.2
@@ -462,44 +472,55 @@ sub_units = {
 		suppression = 2
 
 		forest = {
-		    attack = -0.4
-			movement = -0.4
+		    attack = -0.2
+			defence = -0.2
+			movement = -0.25
 		}
 		hills = {
-		    attack = -0.20
+		    attack = -0.2
+			defence = -0.2
+			movement = -0.2
 		}
 		mountain = 	{
-		    attack = -0.3
+		    attack = -0.5
+			defence = -0.3
+			movement = -0.3
 		}
 		jungle = {
-		    attack = -0.6
-			movement = -0.4
+		    attack = -0.4
+			defence = -0.3
+			movement = -0.3
 		}
 		marsh = {
-		    attack = -0.5 
+		    attack = -0.5
+			defence = -0.3
 			movement = -0.5
 		}
 		urban = {
-			attack = -0.4
-			defence = -0.1
+			attack = -0.2
+			defence = -0.2
+			movement = 0.05
 		}
 		river = { 
-			attack = -0.4 
+			attack = -0.3
+			defence = -0.2
 			movement = -0.4
 		}
 		amphibious = { 
-			attack = -0.8 
-		}
-		plains = {
-			attack = 0.05 
-			movement = 0.05 
-		}
-        desert = {
-			attack = 0.05
-			movement = 0.05 
+			attack = -7.0
 		}
 		fort = {
 			attack = 0.3
+		}
+		plains = {
+			attack = 0.0
+			defence = 0.0 
+			movement = 0.05
+		}
+        desert = {
+			attack = 0.0
+			defence = 0.0 
+			movement = 0.05
 		}
 	}
 }

--- a/common/units/tank_destroyer_brigade.txt
+++ b/common/units/tank_destroyer_brigade.txt
@@ -115,14 +115,14 @@ sub_units = {
 		suppression = 1.5
 		
 		forest = {
-		    attack = -0.15
-			defence = -0.15
+		    attack = -0.12
+			defence = -0.2
 			movement = -0.2
 		}
 		hills = 	{
-		    attack = -0.2
-			defence = -0.2
-			movement = -0.2
+		    attack = -0.12
+			defence = -0.15
+			movement = -0.1
 		}
 		mountain = 	{
 		    attack = -0.4
@@ -130,30 +130,27 @@ sub_units = {
 			movement = -0.4
 		}
 		jungle = {
-		    attack = -0.4
+		    attack = -0.25
 			defence = -0.3
 			movement = -0.4
 		}
 		marsh = {
-		    attack = -0.4 
+		    attack = -0.4
 			defence = -0.3
 			movement = -0.5
 		}
 		urban = {
-			attack = -0.2
+			attack = -0.10
 			defence = -0.2
 			movement = 0.05
 		}
 		river = { 
-			attack = -0.2
+			attack = -0.25
 			defence = -0.1
-			movement = -0.2
+			movement = -0.3
 		}
 		amphibious = { 
 			attack = -5.0
-		}
-		fort = {
-			attack = 0.05
 		}
 		plains = {
 			attack = 0.05
@@ -164,6 +161,9 @@ sub_units = {
 			attack = 0.05
 			defence = 0.0 
 			movement = 0.05
+		}
+		fort = {
+			attack = 0.1
 		}
 	}
 	


### PR DESCRIPTION
India:
 - Red Path is now effected by the famine and can no longer "fix" it
 - Red path cannot remove quit india
 - Core industry focuses has 2 civs removed
 - Red path industry loses 2 civs and 2 mils
 - Red path war idea increased by 1 CG
 - naval focuses switched to allow player to get research slot without getting indian dockyard output idea.
 
 Tank terrain changes
 - Medium Tanks better in forest, hills, jungles, urban but worse on river
 - Heavy armor better on hills, urban, river, worse in forest
 - Medium SPGs/TDs: better than normal medium on forest, hills, jungle, urban, and fort, worse on river
 - Assault gun terrain modifiers similar to tank variants.