### PR TITLE
mod industry bloat reduction

### DIFF
--- a/common/modifiers/00_static_modifiers.txt
+++ b/common/modifiers/00_static_modifiers.txt
@@ -332,16 +332,16 @@ free_license = {
 
 # applies when stability > 50%
 stability_good_modifier = {
-	industrial_capacity_factory = 0.205
-	industrial_capacity_dockyard = 0.205
+	industrial_capacity_factory = 0.123
+	industrial_capacity_dockyard = 0.123
 	consumer_goods_factor = -0.041
 	political_power_factor = 0.125
 }
 
 # applies when stability < 50%
 stability_bad_modifier = {
-	industrial_capacity_factory = -0.50
-	industrial_capacity_dockyard = -0.50
+	industrial_capacity_factory = -0.25
+	industrial_capacity_dockyard = -0.25
 	political_power_factor = -0.2
 }
 

--- a/common/technologies/industry.txt
+++ b/common/technologies/industry.txt
@@ -2620,8 +2620,8 @@ technologies = {
 	###############
 	concentrated_industry = {
 
-		industrial_capacity_factory = 0.1
-		industrial_capacity_dockyard = 0.1
+		industrial_capacity_factory = 0.05
+		industrial_capacity_dockyard = 0.05
 		global_building_slots_factor = 0.25
 		production_factory_start_efficiency_factor = 0.02
 		industry_air_damage_factor = 0.05
@@ -2688,8 +2688,8 @@ technologies = {
 	
 	concentrated_industry2 = {
 
-		industrial_capacity_factory = 0.125
-		industrial_capacity_dockyard = 0.125
+		industrial_capacity_factory = 0.075
+		industrial_capacity_dockyard = 0.075
 		global_building_slots_factor = 0.25
 		production_factory_start_efficiency_factor = 0.02
 		industry_air_damage_factor = 0.05
@@ -2723,8 +2723,8 @@ technologies = {
 	
 	concentrated_industry3 = {
 
-		industrial_capacity_factory = 0.15
-		industrial_capacity_dockyard = 0.15
+		industrial_capacity_factory = 0.10
+		industrial_capacity_dockyard = 0.10
 		global_building_slots_factor = 0.25
 		production_factory_start_efficiency_factor = 0.02
 		industry_air_damage_factor = 0.05
@@ -2757,8 +2757,8 @@ technologies = {
 	
 	concentrated_industry4 = {
 
-		industrial_capacity_factory = 0.175
-		industrial_capacity_dockyard = 0.175
+		industrial_capacity_factory = 0.125
+		industrial_capacity_dockyard = 0.125
 		global_building_slots_factor = 0.25
 		production_factory_start_efficiency_factor = 0.02
 		industry_air_damage_factor = 0.05
@@ -2792,8 +2792,8 @@ technologies = {
 	
 	concentrated_industry5 = {
 
-		industrial_capacity_factory = 0.2
-		industrial_capacity_dockyard = 0.2
+		industrial_capacity_factory = 0.15
+		industrial_capacity_dockyard = 0.15
 		global_building_slots_factor = 0.25
 		production_factory_start_efficiency_factor = 0.02
 		industry_air_damage_factor = 0.05
@@ -2822,8 +2822,8 @@ technologies = {
 	
 	dispersed_industry = {
 
-		industrial_capacity_factory = 0.070
-		industrial_capacity_dockyard = 0.070
+		industrial_capacity_factory = 0.03
+		industrial_capacity_dockyard = 0.03
 		production_factory_start_efficiency_factor = 0.05
 		line_change_production_efficiency_factor = 0.05
 		industry_air_damage_factor = -0.1
@@ -2892,8 +2892,8 @@ technologies = {
 	
 	dispersed_industry2 = {
 
-		industrial_capacity_factory = 0.09
-		industrial_capacity_dockyard = 0.09
+		industrial_capacity_factory = 0.05
+		industrial_capacity_dockyard = 0.05
 		production_factory_start_efficiency_factor = 0.05
 		line_change_production_efficiency_factor = 0.05
 		industry_air_damage_factor = -0.1
@@ -2929,8 +2929,8 @@ technologies = {
 	
 	dispersed_industry3 = {
 
-		industrial_capacity_factory = 0.11
-		industrial_capacity_dockyard = 0.11
+		industrial_capacity_factory = 0.07
+		industrial_capacity_dockyard = 0.07
 		production_factory_start_efficiency_factor = 0.05
 		line_change_production_efficiency_factor = 0.05
 		industry_air_damage_factor = -0.1
@@ -2966,8 +2966,8 @@ technologies = {
 	
 	dispersed_industry4 = {
 
-		industrial_capacity_factory = 0.13
-		industrial_capacity_dockyard = 0.13
+		industrial_capacity_factory = 0.09
+		industrial_capacity_dockyard = 0.09
 		production_factory_start_efficiency_factor = 0.05
 		line_change_production_efficiency_factor = 0.05
 		industry_air_damage_factor = -0.1
@@ -3002,8 +3002,8 @@ technologies = {
 	
 	dispersed_industry5 = {
 
-		industrial_capacity_factory = 0.15
-		industrial_capacity_dockyard = 0.15
+		industrial_capacity_factory = 0.11
+		industrial_capacity_dockyard = 0.11
 		production_factory_start_efficiency_factor = 0.05
 		line_change_production_efficiency_factor = 0.05
 		industry_air_damage_factor = -0.1


### PR DESCRIPTION
Factory output reductions (how much total output has been reduced)
- at 100% stability: 25% >> 15% (-10%)
- all 5 concentrated Techs: 75% >> 50% (-25%)
- all 5 dispersed Techs: 55% >> 35% (-20%)