### PR TITLE
Asia end game mechanics

### DIFF
--- a/common/ideas/japan.txt
+++ b/common/ideas/japan.txt
@@ -125,6 +125,7 @@ ideas = {
 				political_power_gain = -0.35
 				war_support_factor = -0.35
 				stability_factor = -0.35
+				industrial_capacity_dockyard = 0.35
 			}
 		}
 		JAP_island_hopping2 = {
@@ -142,6 +143,7 @@ ideas = {
 				stability_factor = -0.3
 				army_core_defence_factor = 0.05
 				army_core_attack_factor = 0.05
+				industrial_capacity_dockyard = 0.25
 			}
 		}
 		JAP_island_hopping3 = {
@@ -159,6 +161,7 @@ ideas = {
 				stability_factor = -0.25
 				army_core_defence_factor = 0.10
 				army_core_attack_factor = 0.10
+				industrial_capacity_dockyard = 0.15
 			}
 		}
 		JAP_island_hopping4 = {
@@ -176,6 +179,7 @@ ideas = {
 				stability_factor = -0.2
 				army_core_defence_factor = 0.15
 				army_core_attack_factor = 0.15
+				industrial_capacity_dockyard = 0.05
 			}
 		}
 		JAP_island_hopping5 = {

--- a/common/ideas/usa_OAK_ideas.txt
+++ b/common/ideas/usa_OAK_ideas.txt
@@ -307,13 +307,13 @@ ideas = {
 			}
 			targeted_modifier = {
 				tag = GER
-				attack_bonus_against = 0.02
-				defense_bonus_against = 0.02
+				attack_bonus_against = 0.025
+				defense_bonus_against = 0.025
 			}
 			targeted_modifier = {
 				tag = ITA
-				attack_bonus_against = 0.02
-				defense_bonus_against = 0.02
+				attack_bonus_against = 0.025
+				defense_bonus_against = 0.025
 			}
 		}
 		USA_island_hopping13 = {
@@ -333,13 +333,13 @@ ideas = {
 			}
 			targeted_modifier = {
 				tag = GER
-				attack_bonus_against = 0.04
-				defense_bonus_against = 0.04
+				attack_bonus_against = 0.05
+				defense_bonus_against = 0.05
 			}
 			targeted_modifier = {
 				tag = ITA
-				attack_bonus_against = 0.04
-				defense_bonus_against = 0.04
+				attack_bonus_against = 0.05
+				defense_bonus_against = 0.05
 			}
 		}
 		USA_island_hopping14 = {
@@ -359,13 +359,13 @@ ideas = {
 			}
 			targeted_modifier = {
 				tag = GER
-				attack_bonus_against = 0.06
-				defense_bonus_against = 0.06
+				attack_bonus_against = 0.075
+				defense_bonus_against = 0.075
 			}
 			targeted_modifier = {
 				tag = ITA
-				attack_bonus_against = 0.06
-				defense_bonus_against = 0.06
+				attack_bonus_against = 0.075
+				defense_bonus_against = 0.075
 			}
 		}
 		USA_island_hopping15 = {
@@ -385,13 +385,13 @@ ideas = {
 			}
 			targeted_modifier = {
 				tag = GER
-				attack_bonus_against = 0.08
-				defense_bonus_against = 0.08
+				attack_bonus_against = 0.1
+				defense_bonus_against = 0.1
 			}
 			targeted_modifier = {
 				tag = ITA
-				attack_bonus_against = 0.08
-				defense_bonus_against = 0.08
+				attack_bonus_against = 0.1
+				defense_bonus_against = 0.1
 			}
 		}
 		springfield_armory_and_rock_island_arsenal_idea = {

--- a/common/ideas/usa_OAK_ideas.txt
+++ b/common/ideas/usa_OAK_ideas.txt
@@ -26,7 +26,12 @@ ideas = {
 			tag = HUN 
 			attack_bonus_against = -0.1
 			defense_bonus_against = -0.1
-			} 
+			}
+			targeted_modifier = {
+				tag = JAP
+				attack_bonus_against = 0.025
+				defense_bonus_against = 0.025
+			}
 		}
 		ast_capitulated = {
 		 allowed = {
@@ -53,7 +58,12 @@ ideas = {
 			tag = HUN 
 			attack_bonus_against = -0.15
 			defense_bonus_against = -0.15
-			} 
+			}
+			targeted_modifier = {
+				tag = JAP
+				attack_bonus_against = 0.025
+				defense_bonus_against = 0.025
+			}
 		}
 		phi_capitulated = {
 		 allowed = {
@@ -80,7 +90,12 @@ ideas = {
 			tag = HUN 
 			attack_bonus_against = -0.1
 			defense_bonus_against = -0.1
-			} 
+			}
+			targeted_modifier = {
+				tag = JAP
+				attack_bonus_against = 0.025
+				defense_bonus_against = 0.025
+			}
 		}
 		USA_jap_is_ai = {
 			
@@ -110,6 +125,7 @@ ideas = {
 				political_power_gain = -0.35
 				war_support_factor = -0.35
 				stability_factor = -0.35
+				industrial_capacity_dockyard = 0.30
 			}
 		}
 		USA_island_hopping2 = {
@@ -127,6 +143,7 @@ ideas = {
 				stability_factor = -0.3
 				army_core_defence_factor = 0.05
 				army_core_attack_factor = 0.05
+				industrial_capacity_dockyard = 0.20
 			}
 		}
 		USA_island_hopping3 = {
@@ -144,6 +161,7 @@ ideas = {
 				stability_factor = -0.25
 				army_core_defence_factor = 0.10
 				army_core_attack_factor = 0.10
+				industrial_capacity_dockyard = 0.10
 			}
 		}
 		USA_island_hopping4 = {
@@ -292,6 +310,16 @@ ideas = {
 				army_core_defence_factor = 0.55
 				army_core_attack_factor = 0.55
 			}
+			targeted_modifier = {
+				tag = GER
+				attack_bonus_against = 0.02
+				defense_bonus_against = 0.02
+			}
+			targeted_modifier = {
+				tag = ITA
+				attack_bonus_against = 0.02
+				defense_bonus_against = 0.02
+			}
 		}
 		USA_island_hopping13 = {
 			allowed = {
@@ -307,6 +335,16 @@ ideas = {
 				stability_factor = 0.25
 				army_core_defence_factor = 0.60
 				army_core_attack_factor = 0.60
+			}
+			targeted_modifier = {
+				tag = GER
+				attack_bonus_against = 0.04
+				defense_bonus_against = 0.04
+			}
+			targeted_modifier = {
+				tag = ITA
+				attack_bonus_against = 0.04
+				defense_bonus_against = 0.04
 			}
 		}
 		USA_island_hopping14 = {
@@ -324,6 +362,16 @@ ideas = {
 				army_core_defence_factor = 0.65
 				army_core_attack_factor = 0.65
 			}
+			targeted_modifier = {
+				tag = GER
+				attack_bonus_against = 0.06
+				defense_bonus_against = 0.06
+			}
+			targeted_modifier = {
+				tag = ITA
+				attack_bonus_against = 0.06
+				defense_bonus_against = 0.06
+			}
 		}
 		USA_island_hopping15 = {
 			allowed = {
@@ -339,6 +387,16 @@ ideas = {
 				stability_factor = 0.20
 				army_core_defence_factor = 0.70
 				army_core_attack_factor = 0.70
+			}
+			targeted_modifier = {
+				tag = GER
+				attack_bonus_against = 0.08
+				defense_bonus_against = 0.08
+			}
+			targeted_modifier = {
+				tag = ITA
+				attack_bonus_against = 0.08
+				defense_bonus_against = 0.08
 			}
 		}
 		springfield_armory_and_rock_island_arsenal_idea = {

--- a/common/ideas/usa_OAK_ideas.txt
+++ b/common/ideas/usa_OAK_ideas.txt
@@ -29,8 +29,8 @@ ideas = {
 			}
 			targeted_modifier = {
 				tag = JAP
-				attack_bonus_against = 0.025
-				defense_bonus_against = 0.025
+				attack_bonus_against = 0.05
+				defense_bonus_against = 0.05
 			}
 		}
 		ast_capitulated = {
@@ -61,8 +61,8 @@ ideas = {
 			}
 			targeted_modifier = {
 				tag = JAP
-				attack_bonus_against = 0.025
-				defense_bonus_against = 0.025
+				attack_bonus_against = 0.05
+				defense_bonus_against = 0.05
 			}
 		}
 		phi_capitulated = {
@@ -90,11 +90,6 @@ ideas = {
 			tag = HUN 
 			attack_bonus_against = -0.1
 			defense_bonus_against = -0.1
-			}
-			targeted_modifier = {
-				tag = JAP
-				attack_bonus_against = 0.025
-				defense_bonus_against = 0.025
 			}
 		}
 		USA_jap_is_ai = {


### PR DESCRIPTION
1. Japan and USA both have means to get boosts in dockyard output when losing/lost

2. USA encouraged to win the Island hopping war to get buffs in europe (to help finish games)

3. USA gets buffs against Japan as Japan conquers asia to encourage USA to fight in asia to win it back

numbers here:

Japan gets 35% dockyard output when complete loss (incrementally increases as you lose 5/15/25/35)
USA gets 30% dockyard output when complete loss (incrementally increases as you lose 10/20/30)

USA gains incremental increases of atk/def as it wins the island hopping war against Italy and Germany (2/4/6/8%)

USA gets 5% atk/def against Japan for India, and Australia capping

Let me know if the numbers look alright or if numbers should be moved around (perhaps no buff on phillipines capping, but more on india and australia)