### PR TITLE
Designer Amphib Bonuses

### DIFF
--- a/common/country_leader/00_traits.txt
+++ b/common/country_leader/00_traits.txt
@@ -3340,7 +3340,17 @@ leader_traits = {
 
 	GER_mechanized_equipment_manufacturer = {
 		random = no
-
+		equipment_bonus = {
+			mechanized_equipment = {
+				breakthrough = 0.15 hardness = 0.05 armor_value = 0.2 build_cost_ic = 0.05 
+			}
+			armored_cars_equipment = {
+				breakthrough = 0.1 soft_attack = 0.05 hardness = 0.05 build_cost_ic = 0.05 
+			}
+			amphibious_mechanized_equipment = {
+				breakthrough = 0.1 soft_attack = 0.05 hardness = 0.05 build_cost_ic = 0.05 
+			}
+		}
 		ai_will_do = {
 			factor = 1
 		}

--- a/common/ideas/GER.txt
+++ b/common/ideas/GER.txt
@@ -2126,6 +2126,14 @@ ideas = {
 					build_cost_ic = 0.10
 				}
 
+				amphibious_tank_chassis = {
+					reliability = -0.05
+					soft_attack = 0.1
+					hard_attack = 0.1
+					armor_value = 0.05
+					build_cost_ic = 0.10
+				}
+
 			    light_tank_chassis = {
 					reliability = -0.05
 					soft_attack = 0.1
@@ -2177,6 +2185,13 @@ ideas = {
 
 			equipment_bonus = {
 				medium_tank_chassis = {
+					reliability = -0.05
+					breakthrough = 0.1
+					hard_attack = 0.1
+					maximum_speed = 0.1
+					build_cost_ic = 0.1
+				}
+				amphibious_tank_chassis = {
 					reliability = -0.05
 					breakthrough = 0.1
 					hard_attack = 0.1
@@ -2421,6 +2436,15 @@ ideas = {
 					build_cost_ic = 0.1
 				}
 
+				amphibious_tank_chassis = {
+					reliability = -0.1
+					maximum_speed = 0.10 
+					armor_value = 0.05 
+					hard_attack = 0.15 
+					soft_attack = 0.15 
+					build_cost_ic = 0.1
+				}
+
 				medium_tank_aa_chassis = {
 					reliability = -0.1
 					air_attack = 0.1
@@ -2487,6 +2511,15 @@ ideas = {
 		
 			equipment_bonus = {
 				medium_tank_chassis = {
+					reliability = -0.1
+					maximum_speed = 0.10 
+					armor_value = 0.05 
+					hard_attack = 0.15 
+					soft_attack = 0.15 
+					build_cost_ic = 0.1
+				}
+
+				amphibious_tank_chassis = {
 					reliability = -0.1
 					maximum_speed = 0.10 
 					armor_value = 0.05 
@@ -2612,6 +2645,10 @@ ideas = {
 					build_cost_ic = -0.1 
 				}
 
+				amphibious_tank_chassis = {
+					build_cost_ic = -0.1 
+				}
+
 				medium_assault_gun_equipment = {
 					build_cost_ic = -0.1 
 				}
@@ -2664,6 +2701,9 @@ ideas = {
 					build_cost_ic = -0.05 armor_value = 0.1 reliability = -0.05
 				} 
 				medium_tank_chassis = {
+					build_cost_ic = -0.05 armor_value = 0.05 reliability = -0.05
+				}
+				amphibious_tank_chassis = {
 					build_cost_ic = -0.05 armor_value = 0.05 reliability = -0.05
 				}
 				medium_assault_gun_equipment = {
@@ -3442,15 +3482,6 @@ ideas = {
 				motorized_equipment = -0.05
 			}
 			modifier = { materiel_manufacturer_cost_factor = -0.33 }
-			equipment_bonus = {
-				mechanized_equipment = {
-					breakthrough = 0.15 hardness = 0.05 armor_value = 0.2 build_cost_ic = 0.05 
-				}
-				armored_cars_equipment = {
-					breakthrough = 0.1 soft_attack = 0.05 hardness = 0.05 build_cost_ic = 0.05 
-				}
-			}
-			
 			traits = { GER_mechanized_equipment_manufacturer }
 		}
 

--- a/common/ideas/australia.txt
+++ b/common/ideas/australia.txt
@@ -811,6 +811,10 @@ ideas = {
 					    reliability = 0.05
 					    hard_attack = 0.1
 				    }
+					amphibious_tank_chassis = {
+					    reliability = 0.05
+					    hard_attack = 0.1
+					}
 					mechanized_equipment = {
 					    reliability = 0.05
                         hard_attack = 0.1

--- a/common/ideas/britain.txt
+++ b/common/ideas/britain.txt
@@ -2600,6 +2600,12 @@ ideas = {
 			        maximum_speed = 0.05
 					build_cost_ic = 0.10
 				}
+				amphibious_tank_chassis = {
+					soft_attack = 0.10
+					breakthrough = 0.10
+			        maximum_speed = 0.05
+					build_cost_ic = 0.10
+				}
 				medium_tank_aa_chassis = {
 					air_attack = 0.1
 					breakthrough = 0.10

--- a/common/ideas/hungary.txt
+++ b/common/ideas/hungary.txt
@@ -1128,15 +1128,6 @@ ideas = {
 				motorized_equipment = -0.05
 			}
 			modifier = { materiel_manufacturer_cost_factor = -0.33 }
-			equipment_bonus = {
-				mechanized_equipment = {
-					breakthrough = 0.15 hardness = 0.05 armor_value = 0.2 build_cost_ic = 0.05 
-				}
-				armored_cars_equipment = {
-					breakthrough = 0.1 soft_attack = 0.05 hardness = 0.05 build_cost_ic = 0.05 
-				}
-			}
-			
 			traits = { GER_mechanized_equipment_manufacturer }
 		}
 		

--- a/common/ideas/italy.txt
+++ b/common/ideas/italy.txt
@@ -800,6 +800,13 @@ ideas = {
 					defense = 0.1
 					build_cost_ic = 0.05
 				}
+				amphibious_tank_chassis = {
+					reliability = -0.05
+					soft_attack = 0.1
+					hard_attack = 0.1
+					defense = 0.1
+					build_cost_ic = 0.05
+				}
 				medium_assault_gun_equipment = {
 					reliability = -0.05
 					soft_attack = 0.10

--- a/common/ideas/romania.txt
+++ b/common/ideas/romania.txt
@@ -1482,6 +1482,13 @@ ideas = {
 					build_cost_ic = 0.05
 				}
 
+				amphibious_tank_chassis = {
+					reliability = -0.05
+					soft_attack = 0.10
+					armor_value = 0.05				
+					build_cost_ic = 0.05
+				}
+
 				medium_tank_artillery_chassis = {
 					reliability = -0.05
 					soft_attack = 0.10
@@ -1965,15 +1972,6 @@ ideas = {
 				motorized_equipment = -0.05
 			}
 			modifier = { materiel_manufacturer_cost_factor = -0.33 }
-			equipment_bonus = {
-				mechanized_equipment = {
-					breakthrough = 0.15 hardness = 0.2 armor_value = 0.2 build_cost_ic = 0.05 
-				}
-				armored_cars_equipment = {
-					breakthrough = 0.1 soft_attack = 0.05 hardness = 0.05 build_cost_ic = 0.05 
-				}
-			}
-			
 			traits = { GER_mechanized_equipment_manufacturer }
 		}
 	}

--- a/common/ideas/usa.txt
+++ b/common/ideas/usa.txt
@@ -2006,6 +2006,13 @@ ideas = {
 					armor_value = 0.05
 					build_cost_ic = 0.05
 				}
+				amphibious_tank_chassis = {
+					reliability = 0.05
+					soft_attack = 0.1
+					hard_attack = 0.1
+					armor_value = 0.05
+					build_cost_ic = 0.05
+				}
 			    light_tank_chassis = {
 					reliability = 0.05
 					soft_attack = 0.1
@@ -2049,6 +2056,12 @@ ideas = {
 
 			equipment_bonus = {
 				medium_tank_chassis = {
+					reliability = 0.1
+					maximum_speed = 0.15
+					hard_attack = 0.1
+					defense = 0.1
+				}
+				amphibious_tank_chassis = {
 					reliability = 0.1
 					maximum_speed = 0.15
 					hard_attack = 0.1
@@ -2561,11 +2574,7 @@ ideas = {
 				motorized_equipment = -0.05
 			}
 			modifier = { materiel_manufacturer_cost_factor = -0.33 }
-			equipment_bonus = {
-				motorized_equipment = {
-					build_cost_ic = -0.15 instant = yes
-				}
-			}
+			traits = { motorized_equipment_manufacturer }
 		}
 
 		rock_island_arsenal = {


### PR DESCRIPTION
- Added amphibious tank bonuses to any designer with medium tank bonuses
- Added amphibious mech bonuses to Hanomag
- Ford motor company made the same motorized equipment designer every other nation had

I'd also like to mention that going forward, if nations are given the same designer (like Hanomag for GER/ROM/HUN), you should use traits when they give the same bonus, so it only needs to be changed in one place instead of multiple. I updated Hanomag specifically for this change, and may clean up all designers later.