### PR TITLE
USA skill issues

### DIFF
--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -3695,6 +3695,7 @@ focus_tree = {
 			hidden_effect = {
 				news_event = { id = mtg_news.3 days = 3 random_days = 5 }
 			}
+			add_ideas = USA_roosevelts_right_hand_man
 		}
 	}			
 


### PR DESCRIPTION
USA is a lot harder to pick up for new player due to the lack of early game PP generation and they have a noob trap advisor that gives PP. I figure might as well give that advisor for free at the start from a focus so we can help new usa players by getting the advisor for free so they don't waste PP on him and get a little extra PP in the early game to make the nation easier for new players.