### PR TITLE
All Infra Effects Restrained by Construction Tech

### DIFF
--- a/common/decisions/ENG.txt
+++ b/common/decisions/ENG.txt
@@ -1250,25 +1250,13 @@ ENG_budget_decisions = {
 			}
 		  
 			434 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			640 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			432 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			if = {
 				limit = {
@@ -2512,12 +2500,8 @@ operations = {
 		
 		complete_effect = {
 			452  = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-					}
-				}
+				build_2_infrastructure = yes
+			}
 			FRA = {
 				add_timed_idea = {
 					idea = ENG_operation_battleaxe

--- a/common/decisions/GER.txt
+++ b/common/decisions/GER.txt
@@ -386,12 +386,7 @@ special_projects = {
 			custom_effect_tooltip = GER_prepare_to_invade_the_ussr_2_tt
 			hidden_effect = {
 				188 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4
@@ -405,12 +400,7 @@ special_projects = {
 					}
 				}
 				5 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4
@@ -424,12 +414,7 @@ special_projects = {
 					}
 				}
 				92 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4
@@ -443,12 +428,7 @@ special_projects = {
 					}
 				}
 				98 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4
@@ -462,12 +442,7 @@ special_projects = {
 					}
 				}
 				10 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4
@@ -481,12 +456,7 @@ special_projects = {
 					}
 				}
 				88 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4
@@ -500,12 +470,7 @@ special_projects = {
 					}
 				}
 				90 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4
@@ -519,12 +484,7 @@ special_projects = {
 					}
 				}
 				73 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4
@@ -538,12 +498,7 @@ special_projects = {
 					}
 				}
 				76 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4
@@ -557,12 +512,7 @@ special_projects = {
 					}
 				}
 				79 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = air_base
 						level = 4

--- a/common/decisions/RAJ.txt
+++ b/common/decisions/RAJ.txt
@@ -136,11 +136,7 @@ RAJ_imperial_state_of_india = {
 		remove_effect = {
 			429 = {
 				add_extra_state_shared_building_slots = 4
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 7
-				}
+				build_3_infrastructure = yes
 			}
 			add_resource = {
 				state = 429

--- a/common/decisions/SAFR_decisions.txt
+++ b/common/decisions/SAFR_decisions.txt
@@ -312,11 +312,7 @@ SAFR_africa_mandate = {
 			541 = { set_state_flag = swa_develop } 
 			541 = {
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}
@@ -362,11 +358,7 @@ SAFR_africa_mandate = {
 			542 = { set_state_flag = develop_bechuanaland } 
 			542 = {
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}
@@ -453,11 +445,7 @@ SAFR_africa_mandate = {
 			545 = { set_state_flag = develop_rhodesia } 
 			545 = {
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}
@@ -544,11 +532,7 @@ SAFR_africa_mandate = {
 			771 = { set_state_flag = develop_zambia } 
 			771 = {
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}
@@ -594,11 +578,7 @@ SAFR_africa_mandate = {
 			770 = { set_state_flag = develop_malawi } 
 			770 = {
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}
@@ -644,11 +624,7 @@ SAFR_africa_mandate = {
 			546 = { set_state_flag = develop_tanganyika } 
 			546 = {
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}
@@ -694,11 +670,7 @@ SAFR_africa_mandate = {
 			547 = { set_state_flag = develop_kenya } 
 			547 = {
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}
@@ -744,11 +716,7 @@ SAFR_africa_mandate = {
 			548 = { set_state_flag = develop_uganda } 
 			548 = {
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}
@@ -793,11 +761,7 @@ SAFR_africa_mandate = {
 			543 = { set_state_flag = develop_madagascar } 
 			543 = {
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}

--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -650,21 +650,13 @@ SOV_gulag_economy = {
 				limit = {
 					infrastructure < 7 
 				}
-				add_building_construction = {
-					type = infrastructure 
-					level = 1
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 			}
 			random_owned_state = {
 				limit = {
 					infrastructure < 7
 				}
-				add_building_construction = {
-					type = infrastructure 
-					level = 1
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 			}
 		}
 

--- a/common/national_focus/Philippines.txt
+++ b/common/national_focus/Philippines.txt
@@ -90,18 +90,10 @@ focus_tree = {
 
 		completion_reward = {
 			623 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			327 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			#Manila - Daqupan
 			build_railway = {
@@ -263,20 +255,12 @@ focus_tree = {
 
 		completion_reward = {
 		623 = {
-      add_manpower = 150000
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
-			}
+      		add_manpower = 150000
+			build_1_infrastructure = yes
 		}
 		626 = {
-			add_building_construction = {
-				type = industrial_complex
-				level = 1
-				instant_build = yes
-			}
-    add_extra_state_shared_building_slots = 1
+			build_1_infrastructure = yes
+    		add_extra_state_shared_building_slots = 1
 		}
 	}
 }
@@ -294,19 +278,15 @@ focus = {
 	}
 
 	completion_reward = {
-	627 = {
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
+		627 = {
+			build_1_infrastructure = yes
 		}
-	}
 		add_resource = {
 			type = rubber
 			amount = 5
 			state = 627
-	 }
- }
+	 	}
+	}
 }
 
 
@@ -1317,11 +1297,7 @@ focus = {
 		completion_reward = {
 			add_ideas = PHI_american_way
 			327 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}

--- a/common/national_focus/australia.txt
+++ b/common/national_focus/australia.txt
@@ -1932,22 +1932,12 @@ focus_tree = {
 			}
 			
 			285 = {
-
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		
 
 			517 = {
-
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 
@@ -1960,22 +1950,12 @@ focus_tree = {
 			}
 			
 			285 = {
-				
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				set_state_flag = AST_standard_gauge_railway_Inf1
 			}
 
 			517 = {
-				
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				set_state_flag = AST_standard_gauge_railway_Inf2
 			}
 		}
@@ -2060,11 +2040,7 @@ focus_tree = {
 				limit = {
 					has_state_flag = AST_expand_the_northern_railway_Inf
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 
@@ -2083,21 +2059,11 @@ focus_tree = {
 			}
 			
 			520 = {
-				
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				set_state_flag = AST_expand_the_northern_railway_Inf
 			}
 			521 = {
-				
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				set_state_flag = AST_expand_the_northern_railway_Inf
 			}
 		}
@@ -2416,22 +2382,14 @@ focus_tree = {
 				limit = {
 					has_state_flag = AST_western_australian_government_railways_Inf1
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 
 			random_owned_controlled_state = {
 				limit = {
 					has_state_flag = AST_western_australian_government_railways_Inf2
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 
@@ -2444,22 +2402,12 @@ focus_tree = {
 			}
 			
 			522 = {
-				
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				set_state_flag = AST_western_australian_government_railways_Inf1
 			}
 
 			519 = {
-				
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = AST_western_australian_government_railways_Inf2
 			}
 		}
@@ -3752,7 +3700,7 @@ focus_tree = {
 		}	
 	}
 
-focus = {
+	focus = {
 		id = AST_Education_program
 		icon = GFX_goal_tfv_generic_tech_sharing
 		prerequisite = { focus = AST_abandon_wesminster }
@@ -3780,10 +3728,10 @@ focus = {
   				modify_tech_sharing_bonus = {
      				id = commonwealth_research
      				bonus = 0.04
+				}
 			}
 		}
 	}
-}	
 	focus = {
 		id = AST_Homeland_defence
 		icon = GFX_goal_generic_defence
@@ -3999,10 +3947,10 @@ focus = {
 					}
 					level = 2
 					instant_build = yes
-					}
 				}
 			}
 		}
+	}
 		
 	focus = {
 		id = AST_Natives
@@ -4065,7 +4013,6 @@ focus = {
 		completion_reward = {
 			add_ideas = AST_AFTR
 			
-			}
 		}
 	}
 }

--- a/common/national_focus/bulgaria.txt
+++ b/common/national_focus/bulgaria.txt
@@ -80,19 +80,11 @@ focus_tree = {
 					NOT = { state = 48 }
 				}
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			48 = {
 				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = industrial_complex
 					level = 1
@@ -394,25 +386,13 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
 			48 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			212 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			211 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}	
 			#Plovdiv - Varna
 			build_railway = {
@@ -452,11 +432,7 @@ focus_tree = {
 					type = steel
 					amount = 30
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
@@ -1119,11 +1095,7 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
 			48 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = bunker
 					level = 3
@@ -1157,11 +1129,7 @@ focus_tree = {
 						}
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = anti_air_building
 					level = 1
@@ -3080,26 +3048,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes
 				}
-				if = {
-					limit = {
-						infrastructure < 9
-					}
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-					}
-				}
-				else_if = {
-					limit = {
-						infrastructure < 10
-					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
-				}
+				build_2_infrastructure = yes
 			}
 
 			if = {
@@ -3126,16 +3075,7 @@ focus_tree = {
 						level = 1
 						instant_build = yes
 					}
-					if = {
-						limit = {
-							infrastructure < 10
-						}
-						add_building_construction = {
-							type = infrastructure
-							level = 1
-							instant_build = yes
-						}
-					}
+					build_1_infrastructure = yes
 				}
 				random_owned_state = {
 					limit = {
@@ -3155,16 +3095,7 @@ focus_tree = {
 						level = 1
 						instant_build = yes
 					}
-					if = {
-						limit = {
-							infrastructure < 10
-						}
-						add_building_construction = {
-							type = infrastructure
-							level = 1
-							instant_build = yes
-						}
-					}
+					build_1_infrastructure = yes
 				}
 				random_owned_state = {
 					limit = {
@@ -3183,16 +3114,7 @@ focus_tree = {
 						level = 1
 						instant_build = yes
 					}
-					if = {
-						limit = {
-							infrastructure < 10
-						}
-						add_building_construction = {
-							type = infrastructure
-							level = 1
-							instant_build = yes
-						}
-					}
+					build_1_infrastructure = yes
 				}
 				every_owned_state = {
 					limit = {

--- a/common/national_focus/canada.txt
+++ b/common/national_focus/canada.txt
@@ -254,11 +254,7 @@ focus_tree = {
 		completion_reward = {
 			470 = {
 				add_extra_state_shared_building_slots = 1	
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 				set_state_flag = CAN_canada_pacific_railway_Inf
 			}
 			#Vancouver - Northwest Canada
@@ -315,20 +311,12 @@ focus_tree = {
 		completion_reward = {
 			276 = {
 				add_extra_state_shared_building_slots = 1	
-				set_building_level = {
-					type = infrastructure
-					level = 9
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 				set_state_flag = CAN_maritime_colonial_railway_Inf
 			}
 			682 = {
 				add_extra_state_shared_building_slots = 1	
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 				set_state_flag = CAN_maritime_colonial_railway_Inf
 			}
 			#Montreal - Halifax

--- a/common/national_focus/china_communist.txt
+++ b/common/national_focus/china_communist.txt
@@ -712,11 +712,7 @@ focus_tree = {
 
 		complete_tooltip = {
 			622 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_extra_state_shared_building_slots = 1
 			}
 			#Yan'an - Taiyuan
@@ -730,11 +726,7 @@ focus_tree = {
 
 		completion_reward = {
 			622 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_extra_state_shared_building_slots = 1
 			}
 			#Yan'an - Taiyuan

--- a/common/national_focus/china_nationalist.txt
+++ b/common/national_focus/china_nationalist.txt
@@ -188,25 +188,13 @@ focus_tree = {
 
 		completion_reward = {
 			607 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			602 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			605 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 
 		}
@@ -1917,33 +1905,6 @@ focus_tree = {
 		continue_if_invalid = no
 		available_if_capitulated = no
 
-		complete_tooltip = {
-
-		}
-
-		complete_tooltip = {
-			add_building_construction = {
-				type = infrastructure
-				level = 2
-				instant_build = yes
-			}
-			add_building_construction = {
-				type = infrastructure
-				level = 2
-				instant_build = yes
-			}
-			add_building_construction = {
-				type = infrastructure
-				level = 2
-				instant_build = yes
-			}
-			add_building_construction = {
-				type = infrastructure
-				level = 2
-				instant_build = yes
-			}
-		}
-
 		completion_reward = {
 			CHI_hyper_inflation_level_up = yes
 			random_owned_controlled_state = {
@@ -1967,11 +1928,7 @@ focus_tree = {
 						}
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			random_owned_controlled_state = {
 				limit = {
@@ -1994,11 +1951,7 @@ focus_tree = {
 						}
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		
 			random_owned_controlled_state = {
@@ -2022,11 +1975,7 @@ focus_tree = {
 							}
 						}
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-					}
+					build_2_infrastructure = yes
 				}
 				random_owned_controlled_state = {
 					limit = {
@@ -2049,11 +1998,7 @@ focus_tree = {
 							}
 						}
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-					}
+					build_2_infrastructure = yes
 				}
 			}
 		}

--- a/common/national_focus/czechoslovakia.txt
+++ b/common/national_focus/czechoslovakia.txt
@@ -1038,11 +1038,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			71 = {
 				add_extra_state_shared_building_slots = 2
@@ -1051,11 +1047,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 	}
@@ -1102,35 +1094,19 @@ focus_tree = {
 			}
 			9 = {
 				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = infrastructure
-					level = 3
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 			}
 			75 = {
 				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			70 = {
 				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = infrastructure
-					level = 3
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 			}			
 			71 = {
 				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}			
 			#Prague - Bratislava 
 			build_railway = {

--- a/common/national_focus/finland.txt
+++ b/common/national_focus/finland.txt
@@ -33,34 +33,13 @@ focus_tree = {
         ai_will_do = {
 			factor = 10
 		}
-		complete_tooltip = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
-			}
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
-			}
-		}
 
 		completion_reward = {
-        
-        111 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 3
-					instant_build = yes
-				}
+			111 = {
+				build_3_infrastructure = yes
 			}
-		150 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 3
-					instant_build = yes
-				}
+			150 = {
+				build_3_infrastructure = yes
 			}
 		}
 	}

--- a/common/national_focus/france.txt
+++ b/common/national_focus/france.txt
@@ -553,32 +553,16 @@ focus_tree = {
 				}
 			}
 			543 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			772 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			310 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			694 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}
@@ -801,11 +785,7 @@ focus_tree = {
 						size > 0
 					}
 				}
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = FRA_public_works_01
 			}
 			random_owned_controlled_state = {
@@ -816,11 +796,7 @@ focus_tree = {
 						size > 0
 					}
 				}
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = FRA_public_works_01
 			}
 			random_owned_controlled_state = {
@@ -831,11 +807,7 @@ focus_tree = {
 						size > 0
 					}
 				}
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}		
+				build_2_infrastructure = yes		
 				set_state_flag = FRA_public_works_01
 			}
 			random_owned_controlled_state = {
@@ -846,11 +818,7 @@ focus_tree = {
 						size > 0
 					}
 				}
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}					
+				build_3_infrastructure = yes				
 				set_state_flag = FRA_public_works_01
 			}
 		}
@@ -1029,11 +997,7 @@ focus_tree = {
 			random_owned_controlled_state = {
 				prioritize = { 543 }
 				add_extra_state_shared_building_slots = 4
-				set_building_level = {
-					type = infrastructure
-					level = 6
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = arms_factory
 					level = 2
@@ -1250,11 +1214,7 @@ focus_tree = {
 					level = 4
 					instant_build = yes
 				}	
-				set_building_level = {
-					type = infrastructure
-					level = 6
-					instant_build = yes
-				}	
+				build_2_infrastructure = yes
 				add_resource = {
 					type = rubber
 					amount = 8
@@ -3476,11 +3436,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes 
 				}
-				add_building_construction = {
-					type = infrastructure 
-					level = 2
-					instant_build = yes 
-				}
+				build_2_infrastructure = yes
 			}
 			665 = {
 				add_extra_state_shared_building_slots = 2			
@@ -3489,11 +3445,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes 
 				}
-				add_building_construction = {
-					type = infrastructure 
-					level = 2
-					instant_build = yes 
-				}
+				build_2_infrastructure = yes
 			}
 			459 = {
 				add_extra_state_shared_building_slots = 2				
@@ -3502,11 +3454,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes 
 				}
-				add_building_construction = {
-					type = infrastructure 
-					level = 2
-					instant_build = yes 
-				}
+				build_2_infrastructure = yes
 			}
 			460 = {
 				add_extra_state_shared_building_slots = 2
@@ -3515,11 +3463,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes 
 				}
-				add_building_construction = {
-					type = infrastructure 
-					level = 2
-					instant_build = yes 
-				}
+				build_2_infrastructure = yes
 			}
 			461 = {
 				add_extra_state_shared_building_slots = 2				
@@ -3528,27 +3472,15 @@ focus_tree = {
 					level = 2
 					instant_build = yes 
 				}
-				add_building_construction = {
-					type = infrastructure 
-					level = 2
-					instant_build = yes 
-				}
+				build_2_infrastructure = yes
 			}
 			462 = {
-				add_extra_state_shared_building_slots = 3				
-				add_building_construction = {
-					type = infrastructure 
-					level = 3
-					instant_build = yes 
-				}
+				add_extra_state_shared_building_slots = 3
+				build_3_infrastructure = yes
 			}
 			513 = {
-				add_extra_state_shared_building_slots = 3			
-				add_building_construction = {
-					type = infrastructure 
-					level = 3
-					instant_build = yes 
-				}
+				add_extra_state_shared_building_slots = 3
+				build_3_infrastructure = yes
 			}
 		}
 	}
@@ -3735,11 +3667,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 
 			553 = {
@@ -3749,11 +3677,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 
 			554 = {
@@ -3763,11 +3687,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			680 = {
 				add_extra_state_shared_building_slots = 3		
@@ -3776,11 +3696,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 	}

--- a/common/national_focus/generic.txt
+++ b/common/national_focus/generic.txt
@@ -1302,16 +1302,8 @@ focus_tree = {
 		}
 
 		complete_tooltip = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
-			}
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
-			}
+			build_1_infrastructure = yes
+			build_1_infrastructure = yes
 		}
 
 		completion_reward = {
@@ -1336,11 +1328,7 @@ focus_tree = {
 						}
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			random_owned_controlled_state = {
 				limit = {
@@ -1363,11 +1351,7 @@ focus_tree = {
 						}
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}
@@ -1472,16 +1456,8 @@ focus_tree = {
 		}
 
 		complete_tooltip = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
-			}
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
-			}
+			build_1_infrastructure = yes
+			build_1_infrastructure = yes
 		}
 
 		completion_reward = {
@@ -1506,11 +1482,7 @@ focus_tree = {
 						}
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			random_owned_controlled_state = {
 				limit = {
@@ -1533,11 +1505,7 @@ focus_tree = {
 						}
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}

--- a/common/national_focus/germany.txt
+++ b/common/national_focus/germany.txt
@@ -32,40 +32,40 @@ focus_tree = {
 				64 = {
 					if = {
 						limit = { is_controlled_by = ROOT }
-					add_building_construction = {
-						type = infrastructure
-						level = 4
-						instant_build = yes
+						add_building_construction = {
+							type = infrastructure
+							level = 10
+							instant_build = yes
 						}
 					}
 				}
 				59 = {
 					if = {
 						limit = { is_controlled_by = ROOT }
-					add_building_construction = {
-						type = infrastructure
-						level = 4
-						instant_build = yes
+						add_building_construction = {
+							type = infrastructure
+							level = 10
+							instant_build = yes
 						}
 					}
 				}
 				60 = {
 					if = {
 						limit = { is_controlled_by = ROOT }
-					add_building_construction = {
-						type = infrastructure
-						level =4
-						instant_build = yes
+						add_building_construction = {
+							type = infrastructure
+							level = 10
+							instant_build = yes
 						}
 					}
 				}
 				54 = {
 					if = {
 						limit = { is_controlled_by = ROOT }
-					add_building_construction = {
-						type = infrastructure
-						level = 4
-						instant_build = yes
+						add_building_construction = {
+							type = infrastructure
+							level = 10
+							instant_build = yes
 						}
 					}
 				}
@@ -104,11 +104,7 @@ focus_tree = {
 					    amount > 5
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1 
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 				add_resource = {
 				    type = steel
 				    amount = 10
@@ -360,11 +356,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1 
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
             } 
         }
 		
@@ -390,11 +382,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1 
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 				set_state_flag = GER_new_subsidiaries
 			}
 			random_owned_state = {
@@ -412,11 +400,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1 
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 				set_state_flag = GER_new_subsidiaries
 			}	
 			random_owned_state = {
@@ -434,11 +418,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1 
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 				set_state_flag = GER_new_subsidiaries
 			}		
 		}
@@ -525,11 +505,7 @@ focus_tree = {
                 limit = {
                     has_state_flag = GER_resource_rationing
                 }
-                add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = fuel_silo
 					level = 2
@@ -565,11 +541,7 @@ focus_tree = {
 
 			random_owned_state = {
 				prioritize = { 53 56 58 61 62 63 66 67 68 }
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = fuel_silo
 					level = 2
@@ -590,11 +562,7 @@ focus_tree = {
 			}									
 			random_owned_state = {
 				prioritize = { 53 56 58 61 62 63 66 67 68 }
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = fuel_silo
 					level = 2
@@ -614,11 +582,7 @@ focus_tree = {
 			}			
 			random_owned_state = {
 				prioritize = { 53 56 58 61 62 63 66 67 68 }
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = fuel_silo
 					level = 2
@@ -1173,11 +1137,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = anti_air_building
 					level = 5
@@ -1196,11 +1156,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = anti_air_building
 					level = 5
@@ -2772,11 +2728,7 @@ focus_tree = {
 						is_core_of = BUL 
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 			} 
 			add_ideas = TUR_rare_metal_trade_ger
 			TUR = { 

--- a/common/national_focus/hungary.txt
+++ b/common/national_focus/hungary.txt
@@ -1509,27 +1509,15 @@ focus_tree = {
 
 		completion_reward = {
 			155 = {
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = HUN_reintegrate_the_railroads_Inf
 			}
 			43 = {
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = HUN_reintegrate_the_railroads_Inf_2
 			}
 			664 = {
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = HUN_reintegrate_the_railroads_Inf_3
 			}
 		}
@@ -2036,7 +2024,7 @@ focus_tree = {
 	focus = {
 		id = HUN_invests_finland
 		icon = GFX_FIN_the_white_guard
-		mutually_exclusive = ( focus = HUN_invests_romania }
+		mutually_exclusive = { focus = HUN_invests_romania }
 		relative_position_id = HUN_secret_rearmament
 		x = 4
 		y = 0

--- a/common/national_focus/india.txt
+++ b/common/national_focus/india.txt
@@ -76,7 +76,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -125,7 +125,7 @@ focus_tree = {
 		cost = 5
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -166,7 +166,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -207,7 +207,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -252,7 +252,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -294,7 +294,7 @@ focus_tree = {
 		cost = 5
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -335,7 +335,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -376,7 +376,7 @@ focus_tree = {
 		cost = 5
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -427,7 +427,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -470,7 +470,7 @@ focus_tree = {
 		cost = 5
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -511,7 +511,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -564,7 +564,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -609,7 +609,7 @@ focus_tree = {
 		cost = 5
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -646,7 +646,7 @@ focus_tree = {
 		cost = 5
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -684,7 +684,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -735,7 +735,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -797,7 +797,7 @@ focus_tree = {
 		cost = 5
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -839,7 +839,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -911,7 +911,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -1021,7 +1021,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -1078,7 +1078,7 @@ focus_tree = {
 		cost = 7.145
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -1165,7 +1165,7 @@ focus_tree = {
 		cost = 5
 
 		ai_will_do = {
-			factor = 
+			factor = 0
 		}
 
 		available = {
@@ -1444,35 +1444,19 @@ focus_tree = {
 			
    			439 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
    			438 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
    			435 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
    			431 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
    			
 		}
@@ -1486,35 +1470,19 @@ focus_tree = {
 			
    			439 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
    			438 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
    			435 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
    			431 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
    			
 			add_to_variable = {
@@ -1975,77 +1943,37 @@ focus_tree = {
 
 		complete_tooltip = {
 			294 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			658 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			659 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			293 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			765 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 
 		completion_reward = {
    			294 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			658 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			659 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			293 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			765 = {
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}		
 	}
@@ -2083,11 +2011,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes 
 				}
-				set_building_level = {
-					level = 8
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					level = 1
 					type = naval_base
@@ -2110,11 +2034,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes 
 				}
-				set_building_level = {
-					level = 8
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					level = 1
 					type = naval_base
@@ -2215,22 +2135,14 @@ focus_tree = {
 		complete_tooltip = {
 
    			336 = {
-				set_building_level = {
-					type = infrastructure
-					level = 6
-					instant_build = yes
-				}	
+				build_4_infrastructure = yes
 			}
 		}
 
 		completion_reward = {
 
    			336 = {
-				set_building_level = {
-					type = infrastructure
-					level = 6
-					instant_build = yes
-				}
+				build_4_infrastructure = yes
 			}
 
 		}
@@ -2264,11 +2176,7 @@ focus_tree = {
 
 		complete_tooltip = {
    			336 = {
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 4
@@ -2297,11 +2205,7 @@ focus_tree = {
 
 		completion_reward = {
    			336 = {
-				set_building_level = {
-					type = infrastructure
-					level = 8
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 4
@@ -2567,19 +2471,11 @@ focus_tree = {
 					instant_build = yes 
 					level = 2
 				}
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 7
-				}				
+				build_1_infrastructure = yes				
 			}
 			433 = {
 				add_extra_state_shared_building_slots = 4 
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 6
-				}
+				build_1_infrastructure = yes
 			}
 		}
 
@@ -2598,19 +2494,11 @@ focus_tree = {
 					instant_build = yes 
 					level = 2
 				}
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 7
-				}				
+				build_1_infrastructure = yes			
 			}
 			433 = {
 				add_extra_state_shared_building_slots = 4 
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 6
-				}
+				build_1_infrastructure = yes
 			}				
 
 		}
@@ -2656,20 +2544,12 @@ focus_tree = {
 					instant_build = yes 
 					level = 2
 				}
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 7
-				}
+				build_1_infrastructure = yes
 						
 			}
 			437 = {
-				add_extra_state_shared_building_slots = 4 
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 6
-				}
+				add_extra_state_shared_building_slots = 4
+				build_1_infrastructure = yes
 			} 
 		}
 
@@ -2688,20 +2568,12 @@ focus_tree = {
 					instant_build = yes 
 					level = 2
 				}
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 7
-				}
+				build_1_infrastructure = yes
 						
 			}
 			437 = {
-				add_extra_state_shared_building_slots = 4 
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 6
-				}
+				add_extra_state_shared_building_slots = 4
+				build_1_infrastructure = yes
 			}				
  
 		}
@@ -2752,20 +2624,12 @@ focus_tree = {
 					instant_build = yes 
 					level = 2
 				}
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 10
-				}
+				build_1_infrastructure = yes
 						
 			}
 			427 = {
-				add_extra_state_shared_building_slots = 4 
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 6
-				}
+				add_extra_state_shared_building_slots = 4
+				build_1_infrastructure = yes
 			} 
 		}
 
@@ -2789,20 +2653,12 @@ focus_tree = {
 					instant_build = yes 
 					level = 2
 				}
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 10
-				}
+				build_1_infrastructure = yes
 						
 			}
 			427 = {
-				add_extra_state_shared_building_slots = 4 
-				set_building_level = {
-					type = infrastructure
-					instant_build = yes
-					level = 6
-				}
+				add_extra_state_shared_building_slots = 4
+				build_1_infrastructure = yes
 			} 
 			
 			add_to_variable = {
@@ -2995,11 +2851,7 @@ focus_tree = {
 			
 			433 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			
 			build_railway = { # Lucknow to Ahmadabad #
@@ -3010,11 +2862,7 @@ focus_tree = {
 			
 			437 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			
 			build_railway = { # Lucknow to Hyderabad #
@@ -3025,11 +2873,7 @@ focus_tree = {
 			
 			436 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 
@@ -3044,11 +2888,7 @@ focus_tree = {
 			
 			433 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			
 			build_railway = { # Lucknow to Ahmadabad #
@@ -3059,11 +2899,7 @@ focus_tree = {
 			
 			437 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			
 			build_railway = { # Lucknow to Hyderabad #
@@ -3074,11 +2910,7 @@ focus_tree = {
 			
 			436 = {
 				add_extra_state_shared_building_slots = 1
-				set_building_level = {
-					level = 6
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			
 			add_to_variable = {
@@ -3572,12 +3404,7 @@ focus_tree = {
 			unlock_decision_tooltip = RAJ_develop_orissa_mining_expansion
 
 			426 = {
-			
-				set_building_level = {
-					level = 7
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			 
 		}
@@ -3591,12 +3418,7 @@ focus_tree = {
 				value = 5
 			}
 			426 = {
-			
-				set_building_level = {
-					level = 7
-					type = infrastructure
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			 
 		}

--- a/common/national_focus/ireland.txt
+++ b/common/national_focus/ireland.txt
@@ -325,23 +325,13 @@
 		available_if_capitulated = no
 
 		completion_reward = {
-		135 = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes } 
-				}
-		134 = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes } 
-				}
-		}	
-		ai_will_do = {
+			135 = {
+				build_1_infrastructure = yes
+			}
+			134 = {
+				build_1_infrastructure = yes
+			}
 		}
-		
-		
 	}
 	
 	focus = {
@@ -511,23 +501,13 @@
 		available_if_capitulated = no
 
 		completion_reward = {
-		134 = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes } 
-				}
-		135 = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes } 
-				}
-		}	
-		ai_will_do = {
+			134 = {
+				build_1_infrastructure = yes
+			}
+			135 = {
+				build_1_infrastructure = yes
+			}
 		}
-		
-		
 	}
 	
 	focus = {
@@ -552,14 +532,9 @@
 		available_if_capitulated = no
 
 		completion_reward = {
-		113 = {
-			add_building_construction = {
-				type = infrastructure
-				level = 2
-				instant_build = yes } 
-				}
-		}	
-		ai_will_do = {
+			113 = {
+				build_2_infrastructure = yes
+			}
 		}
 	}
 	
@@ -901,29 +876,16 @@
 		available_if_capitulated = no
 
 		completion_reward = {
-		113 = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes } 
-				}
-		134 = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes } 
-				}
-		135 = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes } 
-				}
-		}	
-		ai_will_do = {
+			113 = {
+				build_1_infrastructure = yes
+			}
+			134 = {
+				build_1_infrastructure = yes
+			}
+			135 = {
+				build_1_infrastructure = yes
+			}
 		}
-		
-		
 	}
 	
 	focus = {

--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -29,11 +29,7 @@ focus_tree = {
 
 		completion_reward = {
 				550 = {
-					set_building_level = {
-						type = infrastructure
-						level = 7
-						instant_build = yes
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = naval_base
 						level = 3
@@ -42,12 +38,8 @@ focus_tree = {
 					}
 				}
 				559 = {
-						set_building_level = {
-							type = infrastructure
-							level = 7
-							instant_build = yes
-						}
-						add_building_construction = {
+					build_2_infrastructure = yes
+					add_building_construction = {
 						type = naval_base
 						level = 4
 						province = 12941
@@ -1619,91 +1611,55 @@ focus_tree = {
 			2 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_3_infrastructure = yes
 				}
 			}
 			117 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_3_infrastructure = yes
 				}
 			}
 			156 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_3_infrastructure = yes
 				}
 			}
 			157 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_3_infrastructure = yes
 				}
 			}
 			158 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_3_infrastructure = yes
 				}
 			}
 			159 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_3_infrastructure = yes
 				}
 			}
 			160 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_3_infrastructure = yes
 				}
 			}
 			161 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_3_infrastructure = yes
 				}
 			}
 			162 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_3_infrastructure = yes
 				}
 			}									
 			
@@ -2245,22 +2201,18 @@ focus_tree = {
 
 		completion_reward = {
 			271 = {
-					set_building_level = {
-						type = infrastructure
-						level = 6
-						instant_build = yes
-						}
-			        add_building_construction = {
-						type = arms_factory
-						level = 2
-						instant_build = yes
-					}
-					add_building_construction = {
-						type = industrial_complex
-						level = 2
-						instant_build = yes
-					}
-					add_compliance = 10
+				build_2_infrastructure = yes
+				add_building_construction = {
+					type = arms_factory
+					level = 2
+					instant_build = yes
+				}
+				add_building_construction = {
+					type = industrial_complex
+					level = 2
+					instant_build = yes
+				}
+				add_compliance = 10
 			}
 			550 = {
 				add_compliance = 10
@@ -2423,44 +2375,28 @@ focus_tree = {
 			448  = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+					build_4_infrastructure = yes
 				}
 				add_compliance = 10
 			}
 			449 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 5
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 				add_compliance = 10
 			}
 			451 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 5
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 				add_compliance = 10
 			}
 			662 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					set_building_level = {
-						type = infrastructure
-						level = 4
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 				add_compliance = 10
 			}
@@ -2574,11 +2510,7 @@ focus_tree = {
 					level = 3
 					instant_build = yes
 				}
-				set_building_level = {
-						type = infrastructure
-						level = 8
-						instant_build = yes
-					}
+				build_4_infrastructure = yes
 			}
 			450 = {
 				add_building_construction = {
@@ -2587,11 +2519,7 @@ focus_tree = {
 					level = 5
 					instant_build = yes
 				}
-				set_building_level = {
-						type = infrastructure
-						level = 9
-						instant_build = yes
-					}
+				build_4_infrastructure = yes
 			}
             663 = {
 				add_building_construction = {
@@ -2599,17 +2527,13 @@ focus_tree = {
 					level = 4
 					instant_build = yes
 				}
-				set_building_level = {
-						type = infrastructure
-						level = 5
-						instant_build = yes
-					}
+				build_3_infrastructure = yes
 				add_building_construction = {
 						type = supply_node
 						province = 12079
 						level = 1
 						instant_build = yes
-					}
+				}
 			}
             164 = {
 				add_building_construction = {
@@ -3089,17 +3013,13 @@ focus_tree = {
 		}	
 		completion_reward = {
 			44 = {
-			add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-						}
-						add_building_construction = {
-						type = naval_base
-						level = 2
-						province = 11767
-						instant_build = yes
-						}
+				build_2_infrastructure = yes
+				add_building_construction = {
+					type = naval_base
+					level = 2
+					province = 11767
+					instant_build = yes
+				}
 			}
 			#Tirana - Vlore
 			build_railway = {

--- a/common/national_focus/japan.txt
+++ b/common/national_focus/japan.txt
@@ -110,14 +110,10 @@ focus_tree = {
 				limit = {
 					has_state_flag = JAP_expand_manchurian_railways_2RR
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			build_railway = {
-				level = 3
+				level = 2
 				build_only_on_allied = yes
 				controller_priority = {
 					base = 1
@@ -133,11 +129,7 @@ focus_tree = {
 					is_core_of = MAN
 					NOT = {is_owned_by = CHI}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = JAP_expand_manchurian_railways_2RR
 			}
 			build_railway = {
@@ -1570,11 +1562,7 @@ focus_tree = {
 
 		completion_reward = {
 			610 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 2
@@ -1582,11 +1570,7 @@ focus_tree = {
 				}
 			}
 			611 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 2
@@ -1594,11 +1578,7 @@ focus_tree = {
 				}
 			}
 			609 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 2
@@ -2013,11 +1993,7 @@ focus_tree = {
 			#45,800 IC if infra 7 to 10
 			#Siam
 			289 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 3
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 3
@@ -2032,11 +2008,7 @@ focus_tree = {
 			}
 			#Northern Malay
 			724 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 3
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 3
@@ -3903,11 +3875,7 @@ focus_tree = {
 				}
 			}
 			532 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			532 = {
 				add_building_construction = {
@@ -3949,11 +3917,7 @@ focus_tree = {
 				}
 			}
 			532 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			532 = {
 				add_building_construction = {
@@ -4015,11 +3979,7 @@ focus_tree = {
 				}
 			}
 			529 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			529 = {
 				add_building_construction = {
@@ -4061,11 +4021,7 @@ focus_tree = {
 				}
 			}
 			529 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			529 = {
 				add_building_construction = {

--- a/common/national_focus/manchukuo.txt
+++ b/common/national_focus/manchukuo.txt
@@ -86,32 +86,16 @@ focus_tree = {
     			}
 			}
 			610 = {
-				add_building_construction = {
-					level = 1
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			715 = {
-				add_building_construction = {
-					level = 1
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			716 = {
-				add_building_construction = {
-					level = 1
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			328 = {
-				add_building_construction = {
-					level = 1
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 
@@ -124,32 +108,16 @@ focus_tree = {
     			}
 			}
 			610 = {
-				add_building_construction = {
-					level = 1
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			715 = {
-				add_building_construction = {
-					level = 1
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			716 = {
-				add_building_construction = {
-					level = 1
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			328 = {
-				add_building_construction = {
-					level = 1
-					type = infrastructure
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}
@@ -601,51 +569,31 @@ focus_tree = {
 			if = {
 				limit = { 716 = { is_fully_controlled_by = ROOT } }
 				716 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 			if = {
 				limit = { 328 = { is_fully_controlled_by = ROOT } }
 				328 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				} 
 			}
 			if = {
 				limit = { 714 = { is_fully_controlled_by = ROOT } }
 				714 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				} 
 			}
 			if = {
 				limit = { 610 = { is_fully_controlled_by = ROOT } }
 				610 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				} 
 			}
 			if = {
 				limit = { 717 = { is_fully_controlled_by = ROOT } }
 				717 = {
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 			#Hsinking - Dalian
@@ -2131,32 +2079,16 @@ focus_tree = {
 				target_province = 7940
 			}
 			604 = {
-				add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			754 = {
-				add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			283 = {
-				add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			753 = {
-				add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 		completion_reward = {
@@ -2167,32 +2099,16 @@ focus_tree = {
 				target_province = 7940
 			}
 			604 = {
-				add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			754 = {
-				add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			283 = {
-				add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			753 = {
-				add_building_construction = {
-						type = infrastructure
-						level = 2
-						instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 	}

--- a/common/national_focus/mexico.txt
+++ b/common/national_focus/mexico.txt
@@ -231,11 +231,7 @@ focus_tree = {
 
 		completion_reward = {
 			277 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 3
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 			}
 			every_state = {
 				limit = {
@@ -250,11 +246,7 @@ focus_tree = {
 						state = 481
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}
@@ -299,11 +291,7 @@ focus_tree = {
 						state = 483
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}
@@ -442,39 +430,19 @@ focus_tree = {
 
 		completion_reward = {
 			277 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 3
-					instant_build = yes
-				}
+				build_3_infrastructure = yes
 			}
 			476 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			479 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			477 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			480 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 	}
@@ -966,11 +934,7 @@ focus_tree = {
 
 		completion_reward = {
 		    311 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = arms_factory

--- a/common/national_focus/mongolia.txt
+++ b/common/national_focus/mongolia.txt
@@ -450,25 +450,13 @@ focus_tree = {
 		
 			completion_reward = {				
 				617 = {
-					set_building_level = {
-						type = infrastructure
-						level = 7
-						instant_build = yes
-					}
+					build_2_infrastructure = yes
 				}
 				330 = {
-					set_building_level = {
-						type = infrastructure
-						level = 7
-						instant_build = yes
-					}
+					build_2_infrastructure = yes
 				}
 				618 = {
-					set_building_level = {
-						type = infrastructure
-						level = 7
-						instant_build = yes
-					}
+					build_2_infrastructure = yes
 				}
 				#Ulaanbaatar - Irkutsk
 				build_railway = {
@@ -1405,25 +1393,13 @@ create_country_leader = {
 				technology = tech_logistics_company4
 			}				
 				330 = {
-					set_building_level = {
-						type = infrastructure
-						level = 10
-						instant_build = yes
-					}
+					build_2_infrastructure = yes
 				}
 				617 = {
-					set_building_level = {
-						type = infrastructure
-						level = 10
-						instant_build = yes
-					}
+					build_2_infrastructure = yes
 				}
 				618 = {
-					set_building_level = {
-						type = infrastructure
-						level = 10
-						instant_build = yes
-					}
+					build_2_infrastructure = yes
 				}	
 			#laanbaatar - Irkutsk
 			build_railway = {

--- a/common/national_focus/netherlands.txt
+++ b/common/national_focus/netherlands.txt
@@ -96,18 +96,10 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
 			695 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			689 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 	}
@@ -292,11 +284,7 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
 			309 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				if = {
 					limit = {
 						309 = {
@@ -436,11 +424,7 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
 			689 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				if = {
 					limit = {
 						689 = {
@@ -477,11 +461,7 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY}	
 		completion_reward = {
 			692 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				if = {
 					limit = {
 						692 = {
@@ -501,11 +481,7 @@ focus_tree = {
 				}
 			}
 			308 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				if = {
 					limit = {
 						308 = {
@@ -819,11 +795,7 @@ focus_tree = {
 		completion_reward = {
 			36 = {
 				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 	}
@@ -845,18 +817,10 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
 			7 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			35 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}
@@ -966,19 +930,11 @@ focus_tree = {
 		completion_reward = {
 			35 = {
 				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			36 = {
 				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			hidden_effect = { news_event = { id = mtg_news.47 days = 1 } }
 		}

--- a/common/national_focus/new_zealand.txt
+++ b/common/national_focus/new_zealand.txt
@@ -254,11 +254,7 @@ focus_tree = {
 		completion_reward = {
 		random_owned_controlled_state = {
 				prioritize = { 723 }
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = NZL_national_roads_board_Inf2
 			}
 		}
@@ -288,11 +284,7 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				prioritize = { 284 }
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = NZL_national_roads_board_Inf1
 			}
 

--- a/common/national_focus/poland.txt
+++ b/common/national_focus/poland.txt
@@ -119,19 +119,11 @@ focus_tree = {
 		complete_tooltip = {
 			random_state = {
 				limit = { has_state_flag = POL_fill_the_railways_gaps_1 }
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}	
+				build_1_infrastructure = yes
 			}
 			random_state = {
 				limit = { has_state_flag = POL_fill_the_railways_gaps_2 }
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}	
+				build_1_infrastructure = yes
 			}
 			#Pinsk - Barnowicze
 			build_railway = {
@@ -171,11 +163,7 @@ focus_tree = {
 						}
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				set_state_flag = POL_fill_the_railways_gaps_1
 			}
 			random_owned_controlled_state = {
@@ -199,11 +187,7 @@ focus_tree = {
 						}
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				set_state_flag = POL_fill_the_railways_gaps_2
 			}
 			#Pinsk - Barnowicze
@@ -395,11 +379,7 @@ focus_tree = {
 		complete_tooltip = {
 			random_state = {
 				limit = { has_state_flag = POL_warsaw_main_railway_station_1 }
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			#Lodz - Brzesc Litewski 
 			build_railway = {
@@ -421,11 +401,7 @@ focus_tree = {
 					}
 				}
 				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = POL_warsaw_main_railway_station_1
 			}
 			#Lodz - Brzesc Litewski 

--- a/common/national_focus/portugal.txt
+++ b/common/national_focus/portugal.txt
@@ -41,35 +41,23 @@ focus_tree = {
 			if = {
 				limit = { has_full_control_of_state = 180 }
 				180 = {
-					add_extra_state_shared_building_slots = 1	
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					add_extra_state_shared_building_slots = 1
+					build_1_infrastructure = yes
 				}
 			}	
 			
 			if = {
 				limit = { has_full_control_of_state = 181 }
 				181 = {
-					add_extra_state_shared_building_slots = 1	
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					add_extra_state_shared_building_slots = 1
+					build_1_infrastructure = yes
 				}
 			}
 			if = {
 				limit = { has_full_control_of_state = 179 }
 				179 = {
-					add_extra_state_shared_building_slots = 1	
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					add_extra_state_shared_building_slots = 1
+					build_1_infrastructure = yes
 				}
 			}
 			add_ideas = POR_improved_production

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -347,32 +347,16 @@
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
 			76 = {
-				set_building_level = {
-					type = infrastructure
-					level = 7
-					instant_build = yes 
-				}
+				build_2_infrastructure = yes
 			}
 			84 = {
-				set_building_level = {
-					type = infrastructure
-					level = 7
-					instant_build = yes 
-				}
+				build_2_infrastructure = yes
 			}
 			83 = {
-				set_building_level = {
-					type = infrastructure
-					level = 7
-					instant_build = yes 
-				}
+				build_2_infrastructure = yes
 			}
 			82 = {
-				set_building_level = {
-					type = infrastructure
-					level = 7
-					instant_build = yes 
-				}
+				build_2_infrastructure = yes
 			}
 			add_stability = 0.1 
 			#Ploiesti - Debrecen
@@ -446,11 +430,7 @@
 					is_controlled_by = ROOT
 					is_core_of = ROOT
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			#Constanta - Bessarabia
 			build_railway = {

--- a/common/national_focus/siam.txt
+++ b/common/national_focus/siam.txt
@@ -222,11 +222,9 @@ focus_tree = {
 		}
 
 		complete_tooltip = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
-		   }
+			289 = {
+				build_1_infrastructure = yes
+			}
 		   #Bangkok - Chiang Mai
 			build_railway = {
 				level = 1
@@ -244,11 +242,7 @@ focus_tree = {
         }
 		completion_reward = {
 			289 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			#Bangkok - Chiang Mai
 			build_railway = {
@@ -281,11 +275,9 @@ focus_tree = {
 		}
 
 		complete_tooltip = {
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
-		   }
+			724 = {
+				build_1_infrastructure = yes
+			}
 		   #Bangkok - Hat Yai
 			build_railway = {
 				level = 1
@@ -296,11 +288,7 @@ focus_tree = {
         }
 		completion_reward = {
 			724 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			#Bangkok - Hat Yai
 			build_railway = {

--- a/common/national_focus/south_africa.txt
+++ b/common/national_focus/south_africa.txt
@@ -2970,25 +2970,13 @@ focus_tree = {
 
 		completion_reward = {
 			275 = {
-				set_building_level = {
-					type = infrastructure
-					level = 7
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			719 = {
-				set_building_level = {
-					type = infrastructure
-					level = 6
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			681 = {
-				set_building_level = {
-					type = infrastructure
-					level = 6
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			#Pretoria - Gaborone
 			build_railway = {
@@ -3243,11 +3231,7 @@ focus_tree = {
 
 		completion_reward = {
 			275 = {
-				set_building_level = {
-					type = infrastructure
-					level = 9
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				set_state_flag = SAF_infrastructure_effort_Inf
 			}
 		}

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -284,11 +284,7 @@ focus_tree = {
 					level = 3
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure 
-					level = 1 
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}
@@ -673,11 +669,7 @@ focus_tree = {
 					level = 4
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 1
@@ -742,11 +734,7 @@ focus_tree = {
 					level = 4
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 1
@@ -891,11 +879,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			if = {
 				limit = {
@@ -908,11 +892,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 				random_owned_controlled_state = {
 					add_extra_state_shared_building_slots = 2
@@ -921,11 +901,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 				random_owned_controlled_state = {
 					add_extra_state_shared_building_slots = 2
@@ -934,11 +910,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 				random_owned_controlled_state = {
 					add_extra_state_shared_building_slots = 2
@@ -947,11 +919,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
  			custom_effect_tooltip = SOV_5_year_plan_tt   		
@@ -1011,11 +979,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
  			custom_effect_tooltip = SOV_5_year_plan_tt
 			if	= {
@@ -1033,11 +997,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 				random_owned_controlled_state = {
 					add_extra_state_shared_building_slots = 2
@@ -1046,11 +1006,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 				random_owned_controlled_state = {
 					add_extra_state_shared_building_slots = 2
@@ -1059,11 +1015,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 				random_owned_controlled_state = {
 					add_extra_state_shared_building_slots = 2
@@ -1072,11 +1024,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 			hidden_effect = {
@@ -1791,77 +1739,32 @@ focus_tree = {
 		}
 		
 		completion_reward = {
-			579 = { 
-				add_building_construction = {
-					type = infrastructure
-					level = 5
-					instant_build = yes
-				
-				}
+			579 = {
+				build_4_infrastructure = yes
 			}
-			562 = { 
-				add_building_construction = {
-					type = infrastructure
-					level = 5
-					instant_build = yes
-					
-				}
+			562 = {
+				build_4_infrastructure = yes
 			}
-			644 = { 
-				add_building_construction = {
-					type = infrastructure
-					level = 5
-					instant_build = yes
-					
-				}
+			644 = {
+				build_4_infrastructure = yes
 			}
-			516 = { 
-				add_building_construction = {
-					type = infrastructure
-					level = 5
-					instant_build = yes
-					
-				}
+			516 = {
+				build_4_infrastructure = yes
 			}
-			574 = { 
-				add_building_construction = {
-					type = infrastructure
-					level = 5
-					instant_build = yes
-				
-				}
+			574 = {
+				build_4_infrastructure = yes
 			}
-			575 = { 
-				add_building_construction = {
-					type = infrastructure
-					level = 5
-					instant_build = yes
-					
-				}
+			575 = {
+				build_4_infrastructure = yes
 			}
-			576 = { 
-				add_building_construction = {
-					type = infrastructure
-					level = 5
-					instant_build = yes
-					
-				}
+			576 = {
+				build_4_infrastructure = yes
 			}
-			577 = { 
-				add_building_construction = {
-					type = infrastructure
-					level = 5
-					instant_build = yes
-					
-				}
+			577 = {
+				build_4_infrastructure = yes
 			}
-			580 = { 
-				add_building_construction = {
-					type = infrastructure
-					level = 5
-					instant_build = yes
-					
-				}
+			580 = {
+				build_4_infrastructure = yes
 			}
 			add_political_power = 50 		
 			gulag_economy_effects = yes 
@@ -2705,11 +2608,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			hidden_effect = {
 				every_owned_state = {		
@@ -2771,11 +2670,7 @@ focus_tree = {
 					level = 3
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 1
@@ -2910,11 +2805,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			add_tech_bonus = {
 				category = construction_tech
@@ -2981,11 +2872,7 @@ focus_tree = {
 					level = 3
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 1
@@ -3064,11 +2951,7 @@ focus_tree = {
 					level = 2
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			add_tech_bonus = {
 				category = construction_tech
@@ -3141,11 +3024,7 @@ focus_tree = {
 					level = 3
 					instant_build = yes
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = air_base
 					level = 1
@@ -6457,10 +6336,10 @@ focus_tree = {
 		completion_reward = {
 			219 = {
 				add_building_construction = {
-						type = infrastructure
-						level = 10
-						instant_build = yes
-					}
+					type = infrastructure
+					level = 10
+					instant_build = yes
+				}
 				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = industrial_complex
@@ -6470,10 +6349,10 @@ focus_tree = {
 			}	
 			195 = {
 				add_building_construction = {
-						type = infrastructure
-						level = 10
-						instant_build = yes
-					}
+					type = infrastructure
+					level = 10
+					instant_build = yes
+				}
 				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = industrial_complex
@@ -6483,10 +6362,10 @@ focus_tree = {
 			}	
 			217 = {
 				add_building_construction = {
-						type = infrastructure
-						level = 10
-						instant_build = yes
-					}
+					type = infrastructure
+					level = 10
+					instant_build = yes
+				}
 				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = industrial_complex

--- a/common/national_focus/spain.txt
+++ b/common/national_focus/spain.txt
@@ -780,11 +780,7 @@ technology = construction4
 						state = 41
 					}
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 		}
 	}

--- a/common/national_focus/uk.txt
+++ b/common/national_focus/uk.txt
@@ -2758,11 +2758,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 			else = {
@@ -2774,11 +2770,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 		}
@@ -2805,11 +2797,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 					set_state_flag = ENG_royal_ordinance_factories_2AF
 				}
 				random_owned_controlled_state = {
@@ -2827,11 +2815,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 					set_state_flag = ENG_royal_ordinance_factories_2AF
 				}
 				custom_effect_tooltip = ENG_focus_boost_tt
@@ -2851,12 +2835,7 @@ focus_tree = {
 							level = 3
 							instant_build = yes
 						}
-						add_building_construction = {
-							type = infrastructure
-							level = 1
-							instant_build = yes
-						}
-
+						build_1_infrastructure = yes
 					}
 					random_owned_controlled_state = {
 						limit = {
@@ -2873,12 +2852,7 @@ focus_tree = {
 							level = 3
 							instant_build = yes
 						}
-						add_building_construction = {
-							type = infrastructure
-							level = 1
-							instant_build = yes
-						}
-
+						build_1_infrastructure = yes
 					}
 				}
 			}
@@ -2902,11 +2876,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 					set_state_flag = ENG_royal_ordinance_factories_2AF
 				}
 				random_owned_controlled_state = {
@@ -2924,11 +2894,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 					set_state_flag = ENG_royal_ordinance_factories_2AF
 				}
 				set_country_flag = ENG_royal_ordinance_factories_boosted
@@ -2969,11 +2935,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 			else = {
@@ -2985,11 +2947,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 		}
@@ -3016,11 +2974,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 					set_state_flag = royal_ordinance_focus_2AF
 				}
 				random_owned_controlled_state = {
@@ -3038,11 +2992,7 @@ focus_tree = {
 						level = 2
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 					set_state_flag = royal_ordinance_focus_2AF
 				}
 				custom_effect_tooltip = ENG_focus_boost_tt
@@ -3062,11 +3012,7 @@ focus_tree = {
 							level = 3
 							instant_build = yes
 						}
-						add_building_construction = {
-							type = infrastructure
-							level = 1
-							instant_build = yes
-						}
+						build_1_infrastructure = yes
 						set_state_flag = royal_ordinance_focus_2AF
 					}
 					random_owned_controlled_state = {
@@ -3084,11 +3030,7 @@ focus_tree = {
 							level = 3
 							instant_build = yes
 						}
-						add_building_construction = {
-							type = infrastructure
-							level = 1
-							instant_build = yes
-						}
+						build_1_infrastructure = yes
 						set_state_flag = royal_ordinance_focus_2AF
 					}
 				}
@@ -3113,11 +3055,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 					set_state_flag = royal_ordinance_focus_2AF
 				}
 				random_owned_controlled_state = {
@@ -3135,11 +3073,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes
 					}
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 					set_state_flag = royal_ordinance_focus_2AF
 				}
 				set_country_flag = ENG_military_rearmament_boosted
@@ -6297,11 +6231,7 @@ focus_tree = {
 								} 
 							}
 						}
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
-						}
+						build_3_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 3
@@ -6330,11 +6260,7 @@ focus_tree = {
 								} 
 							}
 						}
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
-						}
+						build_3_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 3
@@ -6361,12 +6287,9 @@ focus_tree = {
 									is_in_faction_with = ENG
 									controls_state = 640
 								} 
-							} }
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
+							} 
 						}
+						build_2_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 2
@@ -6397,11 +6320,7 @@ focus_tree = {
 								} 
 							}
 						}
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
-						}
+						build_2_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 2
@@ -6420,11 +6339,7 @@ focus_tree = {
 								} 
 							}
 						}
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
-						}
+						build_2_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 2
@@ -6441,12 +6356,9 @@ focus_tree = {
 									is_in_faction_with = ENG
 									controls_state = 640
 								} 
-							} }
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
+							} 
 						}
+						build_2_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 1
@@ -6516,11 +6428,7 @@ focus_tree = {
 								} 
 							}
 						}
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
-						}
+						build_2_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 2
@@ -6539,11 +6447,7 @@ focus_tree = {
 								} 
 							}
 						}
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
-						}
+						build_2_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 2
@@ -6560,12 +6464,9 @@ focus_tree = {
 									is_in_faction_with = ENG
 									controls_state = 640
 								} 
-							} }
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
+							} 
 						}
+						build_2_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 1
@@ -6596,11 +6497,7 @@ focus_tree = {
 									} 
 								}
 							}
-							set_building_level = {
-								type = infrastructure
-								level = 5
-								instant_build = yes
-							}
+							build_3_infrastructure = yes
 							add_building_construction = {
 								type = air_base
 								level = 3
@@ -6629,11 +6526,7 @@ focus_tree = {
 									} 
 								}
 							}
-							set_building_level = {
-								type = infrastructure
-								level = 5
-								instant_build = yes
-							}
+							build_3_infrastructure = yes
 							add_building_construction = {
 								type = air_base
 								level = 3
@@ -6660,12 +6553,9 @@ focus_tree = {
 										is_in_faction_with = ENG
 										controls_state = 601
 									} 
-								} }
-							set_building_level = {
-								type = infrastructure
-								level = 5
-								instant_build = yes
+								} 
 							}
+							build_2_infrastructure = yes
 							add_building_construction = {
 								type = air_base
 								level = 2
@@ -6702,11 +6592,7 @@ focus_tree = {
 								} 
 							}
 						}
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
-						}
+						build_3_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 3
@@ -6735,11 +6621,7 @@ focus_tree = {
 								} 
 							}
 						}
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
-						}
+						build_3_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 3
@@ -6766,12 +6648,9 @@ focus_tree = {
 									is_in_faction_with = ENG
 									controls_state = 640
 								} 
-							} }
-						set_building_level = {
-							type = infrastructure
-							level = 5
-							instant_build = yes
+							} 
 						}
+						build_2_infrastructure = yes
 						add_building_construction = {
 							type = air_base
 							level = 2
@@ -9221,11 +9100,7 @@ focus_tree = {
 		}
 		completion_reward = {
 			551  = {
-				set_building_level = {
-					type = infrastructure
-					level = 6
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = naval_base
 					level = 3
@@ -9234,18 +9109,10 @@ focus_tree = {
 				}
 			}
 			457  = {
-				set_building_level = {
-					type = infrastructure
-					level = 6
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 			456  = {
-				set_building_level = {
-					type = infrastructure
-					level = 6
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 			}
 		}
 	}	
@@ -9994,11 +9861,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				set_building_level = {
-					type = infrastructure
-					level = 9 
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 			}
 		}
 
@@ -10019,11 +9882,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				set_building_level = {
-					type = infrastructure
-					level = 9
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 				set_state_flag = ENG_growth_of_advanced_industries_1IC
 			}			
 		}

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -946,11 +946,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes 
 					}
-					set_building_level = {
-						type = infrastructure 
-						level = 6
-						instant_build = yes 
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = fuel_silo 
 						level = 1
@@ -985,11 +981,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes 
 					}
-					set_building_level = {
-						type = infrastructure 
-						level = 6
-						instant_build = yes 
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = fuel_silo 
 						level = 1
@@ -1024,11 +1016,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes 
 					}
-					set_building_level = {
-						type = infrastructure 
-						level = 6
-						instant_build = yes 
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = fuel_silo 
 						level = 1
@@ -1063,11 +1051,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes 
 					}
-					set_building_level = {
-						type = infrastructure 
-						level = 6
-						instant_build = yes 
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = fuel_silo 
 						level = 1
@@ -1102,11 +1086,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes 
 					}
-					set_building_level = {
-						type = infrastructure 
-						level = 6
-						instant_build = yes 
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = fuel_silo 
 						level = 1
@@ -1141,11 +1121,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes 
 					}
-					set_building_level = {
-						type = infrastructure 
-						level = 6
-						instant_build = yes 
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = fuel_silo 
 						level = 1
@@ -1180,11 +1156,7 @@ focus_tree = {
 						level = 3
 						instant_build = yes 
 					}
-					set_building_level = {
-						type = infrastructure 
-						level = 6
-						instant_build = yes 
-					}
+					build_2_infrastructure = yes
 					add_building_construction = {
 						type = fuel_silo 
 						level = 1
@@ -1525,11 +1497,7 @@ focus_tree = {
 					}
 				}
 				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = infrastructure 
-					level = 2
-					instant_build = yes
-				}
+				build_2_infrastructure = yes
 				add_building_construction = {
 					type = dockyard
 					level = 1
@@ -1658,11 +1626,7 @@ focus_tree = {
 					level = 10
 					instant_build = yes 
 				}
-				add_building_construction = {
-					type = infrastructure 
-					level = 1
-					instant_build = yes 
-				}
+				build_1_infrastructure = yes
 				add_building_construction = {
 					type = naval_base
 					level = 10 

--- a/common/national_focus/yugoslavia.txt
+++ b/common/national_focus/yugoslavia.txt
@@ -1001,11 +1001,7 @@ focus_tree = {
 					ROOT = { has_full_control_of_state = PREV }
 					is_core_of = ROOT
 				}
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
-				}
+				build_1_infrastructure = yes
 			}
 			#Novi Sad - Zagreb
 			build_railway = {
@@ -1304,11 +1300,7 @@ focus_tree = {
 				limit = { has_full_control_of_state = 45 }
 				45 = {
 					add_extra_state_shared_building_slots = 2
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 
@@ -1316,11 +1308,7 @@ focus_tree = {
 				limit = { has_full_control_of_state = 105 }
 				105 = {
 					add_extra_state_shared_building_slots = 2
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 
@@ -1328,11 +1316,7 @@ focus_tree = {
 				limit = { has_full_control_of_state = 107 }
 				107 = {
 					add_extra_state_shared_building_slots = 2
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 
@@ -1340,11 +1324,7 @@ focus_tree = {
 				limit = { has_full_control_of_state = 108 }
 				108 = {
 					add_extra_state_shared_building_slots = 2
-					add_building_construction = {
-						type = infrastructure
-						level = 1
-						instant_build = yes
-					}
+					build_1_infrastructure = yes
 				}
 			}
 			#Novi Sad - Skopje

--- a/common/scripted_effects/00_scripted_effects.txt
+++ b/common/scripted_effects/00_scripted_effects.txt
@@ -16,6 +16,568 @@
 #	}
 #
 
+#Infra to Construction Tech
+build_1_infrastructure = {
+	custom_effect_tooltip = build_1_infrastructure_tt
+	hidden_effect = {
+		if = {
+			limit = {
+				owner = {
+					OR = {
+						tag = USA
+						has_tech = construction5
+					}
+				}
+			}
+			add_building_construction = {
+				type = infrastructure
+				instant_build = yes
+				level = 1
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction4 }
+				infrastructure < 9
+			}
+			add_building_construction = {
+				type = infrastructure
+				instant_build = yes
+				level = 1
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction3 }
+				infrastructure < 8
+			}
+			add_building_construction = {
+				type = infrastructure
+				instant_build = yes
+				level = 1
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction2 }
+				infrastructure < 7
+			}
+			add_building_construction = {
+				type = infrastructure
+				instant_build = yes
+				level = 1
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction1 }
+				infrastructure < 6
+			}
+			add_building_construction = {
+				type = infrastructure
+				instant_build = yes
+				level = 1
+			}
+		}
+		else = {
+			limit = {
+				infrastructure < 5
+			}
+			add_building_construction = {
+				type = infrastructure
+				instant_build = yes
+				level = 1
+			}
+		}
+	}
+}
+build_2_infrastructure = {
+	custom_effect_tooltip = build_2_infrastructure_tt
+	hidden_effect = {
+		if = {
+			limit = {
+				owner = {
+					OR = {
+						tag = USA
+						has_tech = construction5
+					}
+				}
+			}
+			add_building_construction = {
+				type = infrastructure
+				instant_build = yes
+				level = 2
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction4 }
+			}
+			if = {
+				limit = { infrastructure < 8 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 9 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction3 }
+			}
+			if = {
+				limit = { infrastructure < 7 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 8 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction2 }
+			}
+			if = {
+				limit = { infrastructure < 6 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 7 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction1 }
+			}
+			if = {
+				limit = { infrastructure < 5 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 6 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else = {
+			if = {
+				limit = { infrastructure < 4 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 5 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+	}
+}
+build_3_infrastructure = {
+	custom_effect_tooltip = build_3_infrastructure_tt
+	hidden_effect = {
+		if = {
+			limit = {
+				owner = {
+					OR = {
+						tag = USA
+						has_tech = construction5
+					}
+				}
+			}
+			add_building_construction = {
+				type = infrastructure
+				instant_build = yes
+				level = 3
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction4 }
+			}
+			if = {
+				limit = { infrastructure < 7 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 8 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 9 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction3 }
+			}
+			if = {
+				limit = { infrastructure < 6 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 7 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 8 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction2 }
+			}
+			if = {
+				limit = { infrastructure < 5 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 6 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 7 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction1 }
+			}
+			if = {
+				limit = { infrastructure < 4 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 5 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 6 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else = {
+			if = {
+				limit = { infrastructure < 3 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 4 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 5 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+	}
+}
+build_4_infrastructure = {
+	custom_effect_tooltip = build_4_infrastructure_tt
+	hidden_effect = {
+		if = {
+			limit = {
+				owner = {
+					OR = {
+						tag = USA
+						has_tech = construction5
+					}
+				}
+			}
+			add_building_construction = {
+				type = infrastructure
+				instant_build = yes
+				level = 4
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction4 }
+			}
+			if = {
+				limit = { infrastructure < 6 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 4
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 7 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 8 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 9 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction3 }
+			}
+			if = {
+				limit = { infrastructure < 5 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 4
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 6 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 7 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 8 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction2 }
+			}
+			if = {
+				limit = { infrastructure < 4 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 4
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 5 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 6 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 7 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				owner = { has_tech = construction1 }
+			}
+			if = {
+				limit = { infrastructure < 3 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 4
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 4 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 5 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 6 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+		else = {
+			if = {
+				limit = { infrastructure < 2 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 4
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 3 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 3
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 4 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 2
+				}
+			}
+			else_if = {
+				limit = { infrastructure < 5 }
+				add_building_construction = {
+					type = infrastructure
+					instant_build = yes
+					level = 1
+				}
+			}
+		}
+	}
+}
+
 #####################################
 ### emergency_factory_conversion ####
 #####################################
@@ -200,11 +762,7 @@ infrastructure_effort_1_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 	
 	random_owned_controlled_state = {
@@ -215,11 +773,7 @@ infrastructure_effort_1_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -230,11 +784,7 @@ infrastructure_effort_1_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 	
 }
@@ -249,11 +799,7 @@ infrastructure_effort_2_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 	
 	random_owned_controlled_state = {
@@ -264,11 +810,7 @@ infrastructure_effort_2_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -279,11 +821,7 @@ infrastructure_effort_2_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -294,11 +832,7 @@ infrastructure_effort_2_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -309,11 +843,7 @@ infrastructure_effort_2_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 }
 
@@ -328,11 +858,7 @@ infrastructure_effort_3_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 	
 	random_owned_controlled_state = {
@@ -343,11 +869,7 @@ infrastructure_effort_3_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -358,11 +880,7 @@ infrastructure_effort_3_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -373,11 +891,7 @@ infrastructure_effort_3_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -388,11 +902,7 @@ infrastructure_effort_3_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -403,11 +913,7 @@ infrastructure_effort_3_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -418,11 +924,7 @@ infrastructure_effort_3_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 
 	random_owned_controlled_state = {
@@ -433,11 +935,7 @@ infrastructure_effort_3_effect = {
 		    infrastructure < 10
 		    }
 		}
-		add_building_construction = {
-			type = infrastructure
-			level = 1
-			instant_build = yes
-		}
+		build_1_infrastructure = yes
 	}
 }
 

--- a/localisation/english/tooltips_l_english.yml
+++ b/localisation/english/tooltips_l_english.yml
@@ -9,6 +9,10 @@
  raider_patrols_CLCA_tt:0 "Note: The above HP modifiers are §Rnegatives§!."
  capital_ship_raiders_BCBB_tt:0 "Note: the above HP, Heavy Attack, and Anti-Air modifiers are §Rnegatives§!."
  ITA_carrier_tt:0 "Lay down two crusier converted carriers"
+ build_1_infrastructure_tt:0 "Add §Gat most 1§! §YInfrastructure§! up to the maximum allowed by our current §YConstruction§! tech."
+ build_2_infrastructure_tt:0 "Add §Gat most 2§! §YInfrastructure§! up to the maximum allowed by our current §YConstruction§! tech."
+ build_3_infrastructure_tt:0 "Add §Gat most 3§! §YInfrastructure§! up to the maximum allowed by our current §YConstruction§! tech."
+ build_4_infrastructure_tt:0 "Add §Gat most 4§! §YInfrastructure§! up to the maximum allowed by our current §YConstruction§! tech."
  
  ##############COMMANDER ABILITIES##############
  


### PR DESCRIPTION
Title, every infra addition that was made set_level changed back to add_level and now every infra addition that wasn't previously set to max infra to 10 now sets to the maximum allowed by current construction tech.

Going forward, use build_x_infrastructure to add infra. It's a custom scripted effect that's all the required if statements. Valid for build 1-4 infra, since there was only one effect that added 5 and using 5 involves more logic than I wanted to write rn. Very minor soviet nerf I guess.