### PR TITLE
Temp fix for NZL annex

### DIFF
--- a/common/decisions/AST.txt
+++ b/common/decisions/AST.txt
@@ -13,11 +13,16 @@ political_actions = {
 			country_exists = NZL
 			OR = {
 				has_completed_focus = AST_support_the_policy_of_appeasement
-				has_completed_focus = AST_invest_in_victory
+				has_war_with = GER
 			}
 		}
 
+		modifier = {
+			consumer_goods_factor = 0.1
+		}
+
 		cost = 0
+		days_remove = 180
 
 		fire_only_once = yes
 


### PR DESCRIPTION
NZL annex decision gives +10% CG for 6 months
NZL can be annexed when at war with germany iinstead of needing invest in victory if Australia first.