### PR TITLE
Minor changes 7 31 23

### DIFF
--- a/common/decisions/ENG.txt
+++ b/common/decisions/ENG.txt
@@ -474,8 +474,8 @@ ENG_budget_decisions = {
 
 		available = {
 			has_completed_focus = shadow_scheme_focus
-			any_state = {
-				is_in_home_area = yes 
+			any_owned_state = {
+				is_in_home_area = yes
 				NOT = {has_state_flag = shadow_scheme_2AF}
 			}
 		}
@@ -497,7 +497,7 @@ ENG_budget_decisions = {
 
 		custom_cost_text = ENG_200_british_money 
 
-		days_re_enable = 90 
+		days_re_enable = 90
 
 		fire_only_once = no
 

--- a/common/national_focus/bulgaria.txt
+++ b/common/national_focus/bulgaria.txt
@@ -1902,7 +1902,7 @@ focus_tree = {
 				name = BUL_modern_tactics
 			    bonus = 0.75
 			    uses = 1
-			    category = naval_air
+			    category = naval_bomber
 			}
 		}
 	}

--- a/common/national_focus/japan.txt
+++ b/common/national_focus/japan.txt
@@ -4765,14 +4765,13 @@ focus_tree = {
 				name = JAP_strengthen_the_fleet_air_arm
 				bonus = 0.75
 				uses = 1
-				category = naval_air
+				category = naval_bomber
 				category = light_fighter
 			}
 			add_tech_bonus = {
 				name = JAP_strengthen_the_fleet_air_arm
 				bonus = 0.75
 				uses = 1
-				category = naval_air
 				category = cas_bomber
 				category = naval_bomber
 			}

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -491,7 +491,7 @@ focus_tree = {
 				name = SOV_carrier_focus
 				bonus = 1.0
 				uses = 2
-				category = naval_air
+				category = naval_bomber
 			}
 		}
 	}

--- a/common/national_focus/uk.txt
+++ b/common/national_focus/uk.txt
@@ -5120,7 +5120,7 @@ focus_tree = {
 					name = JAP_strengthen_the_fleet_air_arm
 					bonus = 2
 					uses = 2
-					category = naval_air
+					category = naval_bomber
 				}
 				add_doctrine_cost_reduction = {
 					name = JAP_strengthen_the_fleet_air_arm
@@ -5147,7 +5147,7 @@ focus_tree = {
 					name = JAP_strengthen_the_fleet_air_arm
 					bonus = 1
 					uses = 2
-					category = naval_air
+					category = naval_bomber
 				}
 				add_doctrine_cost_reduction = {
 					name = JAP_strengthen_the_fleet_air_arm
@@ -5183,7 +5183,7 @@ focus_tree = {
 					name = JAP_strengthen_the_fleet_air_arm
 					bonus = 1
 					uses = 2
-					category = naval_air
+					category = naval_bomber
 				}
 				add_doctrine_cost_reduction = {
 					name = JAP_strengthen_the_fleet_air_arm
@@ -5210,7 +5210,7 @@ focus_tree = {
 						name = JAP_strengthen_the_fleet_air_arm
 						bonus = 2
 						uses = 2
-						category = naval_air
+						category = naval_bomber
 					}
 					add_doctrine_cost_reduction = {
 						name = JAP_strengthen_the_fleet_air_arm
@@ -5242,7 +5242,7 @@ focus_tree = {
 					name = JAP_strengthen_the_fleet_air_arm
 					bonus = 2
 					uses = 2
-					category = naval_air
+					category = naval_bomber
 				}
 				add_doctrine_cost_reduction = {
 					name = JAP_strengthen_the_fleet_air_arm

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -1936,7 +1936,7 @@ focus_tree = {
 				name = USA_naval_aviation
 				bonus = 1
 				uses = 2
-				category = naval_air
+				category = naval_bomber
 			}
 			add_doctrine_cost_reduction = {
 				name = USA_naval_aviation

--- a/interface/countryconstructionsview.gui
+++ b/interface/countryconstructionsview.gui
@@ -289,7 +289,7 @@ guiTypes = {
 			
 			buttonType = {
 				name = "convert_ic_button"
-				position = { x = -98 y = 377 }
+				position = { x = -50 y = 377 }
 				quadTextureSprite ="GFX_convert_ic_button"
 				buttonFont = "Main_14_black"
 				Orientation = "UPPER_RIGHT"


### PR DESCRIPTION
- Fixed shadow scheme decision not disabling when no more states were eligible
- All "Naval Air" research bonuses changed to "Naval Bombers" so they're not consumed on the super-short CV plane researches
- Fixed the Build Rocket Site button being hidden