### PR TITLE
Raj stats nerfs

### DIFF
--- a/common/ideas/british_raj.txt
+++ b/common/ideas/british_raj.txt
@@ -174,8 +174,6 @@ ideas = {
 			modifier = {
 				stability_weekly = 0.001
 				political_power_factor = 0.10
-				army_core_attack_factor = 0.025
-				army_core_defence_factor = 0.025
 			}
 		}
 		
@@ -201,8 +199,6 @@ ideas = {
 			modifier = {
 				stability_weekly = 0.001
 				political_power_factor = 0.10
-				army_core_attack_factor = 0.06
-				army_core_defence_factor = 0.06
 			}
 		}
 
@@ -329,10 +325,9 @@ ideas = {
 
 			removal_cost = -1
 
-			targeted_modifier = {
-				tag = JAP
-				attack_bonus_against = 0.03
-				defense_bonus_against = 0.03
+			modifier = {
+				army_morale_factor = 0.025
+				army_org_factor = 0.025
 			}
 		}
 
@@ -355,10 +350,9 @@ ideas = {
 
 			removal_cost = -1
 
-			targeted_modifier = {
-				tag = JAP
-				attack_bonus_against = 0.05
-				defense_bonus_against = 0.05
+			modifier = {
+				army_morale_factor = 0.05
+				army_org_factor = 0.05
 			}
 		}
 
@@ -382,13 +376,8 @@ ideas = {
 			removal_cost = -1
 
 			modifier = {
-				army_morale_factor = 0.05
-				army_org_factor = 0.03
-			}
-			targeted_modifier = {
-				tag = JAP
-				attack_bonus_against = 0.08
-				defense_bonus_against = 0.08
+				army_morale_factor = 0.075
+				army_org_factor = 0.05
 			}
 		}
 
@@ -412,13 +401,8 @@ ideas = {
 			removal_cost = -1
 
 			modifier = {
-				army_morale_factor = 0.075
+				army_morale_factor = 0.1
 				army_org_factor = 0.05
-			}
-			targeted_modifier = {
-				tag = JAP
-				attack_bonus_against = 0.12
-				defense_bonus_against = 0.12
 			}
 		}
 
@@ -1014,34 +998,6 @@ ideas = {
 
 		}
 
-		RAJ_indian_officers_2 = {
-
-			picture = chi_army_corruption
-
-
-			allowed = {
-				always = no
-			}
-
-			allowed_civil_war = {
-				always = yes
-			}
-
-			modifier = {
-				army_core_attack_factor = 0.05
-			}
-
-			modifier = {
-				army_core_defence_factor = 0.05
-			}
-
-			removal_cost = -1
-
-			modifier = {
-				army_morale_factor = 0.1
-			}
-		}
-
 		RAJ_army_corruption_1 = {
 
 			picture = chi_army_corruption
@@ -1080,8 +1036,6 @@ ideas = {
 
 			modifier = {
 				land_doctrine_cost_factor = 0.10
-				army_core_attack_factor = 0.025
-				army_core_defence_factor = 0.025
 			}
 
 			removal_cost = -1
@@ -1103,8 +1057,6 @@ ideas = {
 			}
 
 			modifier = {
-				army_core_attack_factor = 0.07
-				army_core_defence_factor = 0.07
 				land_doctrine_cost_factor = -0.10
 			}
 
@@ -1112,28 +1064,6 @@ ideas = {
 
 		}
 
-		RAJ_army_corruption_3 = {
-
-			picture = chi_army_corruption2
-
-			name = CHI_army_corruption
-
-			allowed = {
-				always = no
-			}
-
-			allowed_civil_war = {
-				always = yes
-			}
-
-			modifier = {
-				army_core_attack_factor = 0.05
-				army_core_defence_factor = 0.05
-			}
-
-			removal_cost = -1
-
-		}
 
 		RAJ_agrarian_society = {
 

--- a/common/ideas/british_raj.txt
+++ b/common/ideas/british_raj.txt
@@ -325,10 +325,11 @@ ideas = {
 
 			removal_cost = -1
 
-			modifier = {
-				army_morale_factor = 0.025
-				army_org_factor = 0.025
-			}
+			targeted_modifier = {
+				tag = JAP
+				attack_bonus_against = 0.025
+				defense_bonus_against = 0.025
+		}
 		}
 
 		RAJ_prince_war_demands_siam = {
@@ -350,10 +351,10 @@ ideas = {
 
 			removal_cost = -1
 
-			modifier = {
-				army_morale_factor = 0.05
-				army_org_factor = 0.05
-			}
+			targeted_modifier = {
+				tag = JAP
+				attack_bonus_against = 0.05
+				defense_bonus_against = 0.05
 		}
 
 		RAJ_prince_war_demands_singapore = {
@@ -374,11 +375,14 @@ ideas = {
 			}
 
 			removal_cost = -1
-
 			modifier = {
-				army_morale_factor = 0.075
-				army_org_factor = 0.05
+				army_morale_factor = 0.05
+				army_org_factor = 0.03
 			}
+			targeted_modifier = {
+				tag = JAP
+				attack_bonus_against = 0.075
+				defense_bonus_against = 0.075
 		}
 
 		RAJ_prince_war_demands_indochina = {
@@ -399,7 +403,10 @@ ideas = {
 			}
 
 			removal_cost = -1
-
+			targeted_modifier = {
+				tag = JAP
+				attack_bonus_against = 0.1
+				defense_bonus_against = 0.1
 			modifier = {
 				army_morale_factor = 0.1
 				army_org_factor = 0.05


### PR DESCRIPTION
Removed every core buffs and attack buffs vs japan raj gets from its focus. It still has the bonuses in jungle with gukhas to match japan's buffs.