### PR TITLE
Marines buff

### DIFF
--- a/common/units/infantry.txt
+++ b/common/units/infantry.txt
@@ -701,14 +701,14 @@ sub_units = {
 			defence = 0.1
 		}
 		jungle = {
-			attack = 0.075
-			defence = 0.075
-			movement = 0.075
+			attack = 0.2
+			defence = 0.1
+			movement = 0.1
 		}
 		marsh = {
-			attack = 0.075
-			defence = 0.075
-			movement = 0.075
+			attack = 0.2
+			defence = 0.1
+			movement = 0.1
 		}
 		urban = {
 			attack = 0.05


### PR DESCRIPTION
Compared to Mountaineers who have 20% / 40% stat buffs in their specilized terrain, marines are really underperforming and deserve a bump to have better stats in the terrain they are supposed to be good in.