### PR TITLE
Naval Act Changes

### DIFF
--- a/common/ideas/usa.txt
+++ b/common/ideas/usa.txt
@@ -567,12 +567,9 @@ ideas = {
 			removal_cost = -1
 
 			modifier = {
-				industrial_capacity_dockyard = 0.15
 				production_speed_dockyard_factor = 0.5
-				production_speed_naval_base_factor = 0.2
-				naval_equipment_upgrade_xp_cost = -0.5
+				production_speed_naval_base_factor = 0.25
 				consumer_goods_factor = 0.02
-				political_power_gain = -0.2
 			}
 		}
 

--- a/common/ideas/usa.txt
+++ b/common/ideas/usa.txt
@@ -568,12 +568,10 @@ ideas = {
 
 			modifier = {
 				industrial_capacity_dockyard = 0.15
-				production_speed_dockyard_factor = 0.2
+				production_speed_dockyard_factor = 0.5
 				production_speed_naval_base_factor = 0.2
 				naval_equipment_upgrade_xp_cost = -0.5
-				#refit_ic_cost = -0.25
-				refit_speed = 0.2
-				consumer_goods_factor = 0.03
+				consumer_goods_factor = 0.02
 				political_power_gain = -0.2
 			}
 		}

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -2009,6 +2009,10 @@ focus_tree = {
 				idea = USA_massive_funding_project
 				days = 120 
 			}
+			add_timed_idea = {
+				idea = JAP_modernize_the_fleet
+				days = 365 
+			}
 		}
 		
 		completion_reward = {
@@ -2083,6 +2087,10 @@ focus_tree = {
 			add_timed_idea = {
 				idea = USA_massive_funding_project
 				days = 120 
+			}
+			add_timed_idea = {
+				idea = JAP_modernize_the_fleet
+				days = 365 
 			}
 		}
 	}					


### PR DESCRIPTION
- USA Naval Act idea
  - No longer costs political power
  - No longer gives 20% refit speed, 15% dock output, -50% module upgrade xp cost
  - Dock construction bonus increased from 20% to 50%
  - Naval base construction bonus increased from 20% to 25%
  - Consumer goods cost reduced from 3% to 2%
- Two Ocean Navy Act now gives the Modernize the Fleet refit idea for 1 year

Changes give USA the refit bonus every other naval major has, and retune Naval Act of 1936 to function as an early way to build dockyards (removing unnecessary output+refit, increasing dock construction speed to compensate for elongated London Naval Treaty)