### PR TITLE
light tank adjustments

### DIFF
--- a/common/units/equipment/x_tank_chassis.txt
+++ b/common/units/equipment/x_tank_chassis.txt
@@ -220,7 +220,7 @@ equipments = {
 		}
 		
 		#Misc Abilities
-		maximum_speed = 7.0
+		maximum_speed = 6.8
 		reliability = 0.69
 
 		#Defensive Abilities
@@ -254,7 +254,7 @@ equipments = {
 		is_convertable = yes
 
 		#Misc Abilities
-		maximum_speed = 7.6
+		maximum_speed = 7.0
 		reliability = 0.70
 
 		#Defensive Abilities
@@ -288,7 +288,7 @@ equipments = {
 		is_convertable = yes
 
 		#Misc Abilities
-		maximum_speed = 8.2
+		maximum_speed = 7.4
 		reliability = 0.72
 
 		#Defensive Abilities
@@ -322,7 +322,7 @@ equipments = {
 		is_convertable = yes
 		
 		#Misc Abilities
-		maximum_speed = 8.8
+		maximum_speed = 7.8
 		reliability = 0.74
 		#Defensive Abilities
 		defense = 10
@@ -355,7 +355,7 @@ equipments = {
 		is_convertable = yes
 
 		#Misc Abilities
-		maximum_speed = 9.1
+		maximum_speed = 8.0
 		reliability = 0.75
 		#Defensive Abilities
 		defense = 11
@@ -388,7 +388,7 @@ equipments = {
 		is_convertable = yes
 		
 		#Misc Abilities
-		maximum_speed = 9.4
+		maximum_speed = 8.2
 		reliability = 0.76
 		
 		#Defensive Abilities
@@ -423,7 +423,7 @@ equipments = {
 		is_convertable = yes
 
 		#Misc Abilities
-		maximum_speed = 10
+		maximum_speed = 8.4
 		reliability = 0.78
 
 		#Defensive Abilities
@@ -467,7 +467,7 @@ equipments = {
 
 		fuel_consumption = 1.6		
 		#Misc Abilities
-		maximum_speed = 8.2
+		maximum_speed = 7.4
 		reliability = 0.72
 
 		#Defensive Abilities
@@ -505,7 +505,7 @@ equipments = {
 		}
 		fuel_consumption = 1.7
 		#Misc Abilities
-		maximum_speed = 8.8
+		maximum_speed = 7.8
 		reliability = 0.74
 
 		#Defensive Abilities
@@ -541,7 +541,7 @@ equipments = {
 		}
 		fuel_consumption = 1.7	
 		#Misc Abilities
-		maximum_speed = 9.1
+		maximum_speed = 8.0
 		reliability = 0.75
 
 		#Defensive Abilities
@@ -577,7 +577,7 @@ equipments = {
 		}
 		fuel_consumption = 1.8	
 		#Misc Abilities
-		maximum_speed = 9.4
+		maximum_speed = 8.2
 		reliability = 0.76
 
 		#Defensive Abilities
@@ -613,7 +613,7 @@ equipments = {
 		}
 		fuel_consumption = 1.9	
 		#Misc Abilities
-		maximum_speed = 10
+		maximum_speed = 8.4
 		reliability = 0.78
 
 		#Defensive Abilities
@@ -654,7 +654,7 @@ equipments = {
 			tank_at_upgrade
 		}
 		
-		maximum_speed = 8.2
+		maximum_speed = 7.4
 		reliability = 0.72
 
 		#Defensive Abilities
@@ -690,7 +690,7 @@ equipments = {
 			light_tank_equipment_1938	
 		}
 		
-		maximum_speed = 8.8
+		maximum_speed = 7.8
 		reliability = 0.74
 		fuel_consumption = 1.7	
 		#Defensive Abilities
@@ -724,7 +724,7 @@ equipments = {
 		    light_tank_equipment_1938
 			
 		}
-		maximum_speed = 9.1
+		maximum_speed = 8.0
 		reliability = 0.75
 		fuel_consumption = 1.7	
 		#Defensive Abilities
@@ -758,7 +758,7 @@ equipments = {
 			light_tank_equipment_1940		
 		}
 		
-		maximum_speed = 9.4
+		maximum_speed = 8.2
 		reliability = 0.76
 		fuel_consumption = 1.8
 		#Defensive Abilities
@@ -794,7 +794,7 @@ equipments = {
 			
 		}
 		fuel_consumption = 1.9	
-		maximum_speed = 10
+		maximum_speed = 8.4
 		reliability = 0.78
 
 		#Defensive Abilities
@@ -836,7 +836,7 @@ equipments = {
 		}
 		
 		#Misc Abilities
-		maximum_speed = 8.2
+		maximum_speed = 7.4
 		reliability = 0.72
 
 		#Defensive Abilities
@@ -874,7 +874,7 @@ equipments = {
 		}
 		fuel_consumption = 1.4	
 		#Misc Abilities
-		maximum_speed = 8.8
+		maximum_speed = 7.8
 		reliability = 0.74
 
 		#Defensive Abilities
@@ -910,7 +910,7 @@ equipments = {
 		}
 		fuel_consumption = 1.4	
 		#Misc Abilities
-		maximum_speed = 9.1
+		maximum_speed = 8.0
 		reliability = 0.75
 
 		#Defensive Abilities
@@ -945,7 +945,7 @@ equipments = {
 		}
 		fuel_consumption = 1.5	
 		#Misc Abilities
-		maximum_speed = 9.4
+		maximum_speed = 8.2
 		reliability = 0.76
 	    defense = 6
 		breakthrough = 20
@@ -981,7 +981,7 @@ equipments = {
 		}
 		fuel_consumption = 1.6
 		#Misc Abilities
-		maximum_speed = 10
+		maximum_speed = 8.4
 		reliability = 0.78
 
 		#Defensive Abilities

--- a/common/units/equipment/x_tank_chassis.txt
+++ b/common/units/equipment/x_tank_chassis.txt
@@ -477,7 +477,7 @@ equipments = {
 		hardness = 0.55
 		
 		#Offensive Abilities
-		soft_attack = 37
+		soft_attack = 34
 		hard_attack = 1.7
 		ap_attack = 12
 		air_attack = 0
@@ -515,7 +515,7 @@ equipments = {
 		armor_value = 30.6
 
 		#Offensive Abilities
-		soft_attack = 39
+		soft_attack = 36
 		hard_attack = 1.9
 		ap_attack = 14
 
@@ -551,7 +551,7 @@ equipments = {
 		armor_value = 33.75
 
 		#Offensive Abilities
-		soft_attack = 42
+		soft_attack = 37.5
 		hard_attack = 2
 		ap_attack = 15
 
@@ -587,7 +587,7 @@ equipments = {
 		armor_value = 36.9
 
 		#Offensive Abilities
-		soft_attack = 43
+		soft_attack = 39
 		hard_attack = 2.1
 		ap_attack = 16
 
@@ -623,7 +623,7 @@ equipments = {
 		armor_value = 43.2
 
 		#Offensive Abilities
-		soft_attack = 45
+		soft_attack = 42
 		hard_attack = 2.3
 		ap_attack = 18
 

--- a/common/units/sp_anti-air_brigade.txt
+++ b/common/units/sp_anti-air_brigade.txt
@@ -23,7 +23,7 @@ sub_units = {
 		combat_width = 2
 
 		need = {
-			light_tank_aa_chassis = 25
+			light_tank_aa_chassis = 30
 		}
 		manpower = 250
 		max_organisation = 0

--- a/common/units/sp_artillery_brigade.txt
+++ b/common/units/sp_artillery_brigade.txt
@@ -24,7 +24,7 @@ sub_units = {
 		combat_width = 2
 
 		need = {
-			light_tank_artillery_chassis = 25
+			light_tank_artillery_chassis = 30
 		}
 		manpower = 400
 		max_organisation = 0

--- a/common/units/tank_destroyer_brigade.txt
+++ b/common/units/tank_destroyer_brigade.txt
@@ -23,7 +23,7 @@ sub_units = {
 		combat_width = 2
 
 		need = {
-			light_tank_destroyer_chassis = 25
+			light_tank_destroyer_chassis = 30
 		}
 		manpower = 400
 		max_organisation = 0


### PR DESCRIPTION
light SPGs: lower soft by 3 and correct the scaling (more in line with light tank TD stat bonuses)
light tank variants: battalion equipment cost increased by 5

dedicated variant divisions that some folks have made will probably see a 30-50 soft attack reduction depending on various factors.

While it is good to see light tanks and variants being used - it is also realistic to suggest that they are probably too efficient at knocking over other divisions.
