### PR TITLE
5 starting research slots for italy at start

### DIFF
--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -982,7 +982,6 @@ focus_tree = {
 
 		completion_reward = {
 			add_to_tech_sharing_group = axis_research
-			add_research_slot = 1
 			
 		}
 	}

--- a/history/countries/ITA - Italy.txt
+++ b/history/countries/ITA - Italy.txt
@@ -2,7 +2,7 @@
 
 oob = "ITA_1936"
 
-set_research_slots = 4
+set_research_slots = 5
 
 add_ideas = {
 	vittorio_emanuele


### PR DESCRIPTION
They have to tech navy, infantry, air and sometimes even tanks, but only starts with 4 tech slots which is no enough. You can get 6 but it's too late into the game imo and makes it a little too hard for italy to get techs it needs compared to uk that can get 7 techs slots 2 focuses in. Italy will lose the research slot on the axis research focus to make it still be a total of 6, but easier to achieve. 