### PR TITLE
Supremacy rebalance

### DIFF
--- a/common/defines/00_defines.lua
+++ b/common/defines/00_defines.lua
@@ -1630,14 +1630,14 @@ NNavy = {
 	MISSION_SUPREMACY_RATIOS = { -- supremacy multipliers for different mission types
 		0.0, -- HOLD
 		1.0, -- PATROL
-		1.0, -- STRIKE FORCE
-		0.5, -- CONVOY RAIDING
-		0.5, -- CONVOY ESCORT
+		0.1, -- STRIKE FORCE
+		0.4, -- CONVOY RAIDING
+		0.6, -- CONVOY ESCORT
 		0.3, -- MINES PLANTING
 		0.3, -- MINES SWEEPING
 		0.0, -- TRAIN
 		0.0, -- RESERVE_FLEET
-		1.0, -- NAVAL_INVASION_SUPPORT
+		0.5, -- NAVAL_INVASION_SUPPORT
 	},
 
 	SUPREMACY_PER_SHIP_PER_MANPOWER = 0.05,							-- supremacy of a ship is calculated using its IC, manpower and a base define

--- a/common/units/equipment/modules/00_ship_modules.txt
+++ b/common/units/equipment/modules/00_ship_modules.txt
@@ -1370,7 +1370,7 @@ equipment_modules = {
 
 		add_stats = {
 			torpedo_attack = 30
-			naval_torpedo_hit_chance_factor = 0.75
+			naval_torpedo_hit_chance_factor = 0.075
 			build_cost_ic = 130
 		}
 		multiply_stats = {

--- a/common/units/equipment/modules/00_ship_modules.txt
+++ b/common/units/equipment/modules/00_ship_modules.txt
@@ -1370,7 +1370,7 @@ equipment_modules = {
 
 		add_stats = {
 			torpedo_attack = 30
-			naval_torpedo_hit_chance_factor = 0.1
+			naval_torpedo_hit_chance_factor = 0.75
 			build_cost_ic = 130
 		}
 		multiply_stats = {
@@ -1397,7 +1397,7 @@ equipment_modules = {
 
 		add_stats = {
 			torpedo_attack = 35
-			naval_torpedo_hit_chance_factor = 0.15
+			naval_torpedo_hit_chance_factor = 0.1
 			build_cost_ic = 165
 		}
 		multiply_stats = {
@@ -1421,7 +1421,7 @@ equipment_modules = {
 
 		add_stats = {
 			torpedo_attack = 40
-			naval_torpedo_hit_chance_factor = 0.20
+			naval_torpedo_hit_chance_factor = 0.125
 			build_cost_ic = 200
 		}
 		multiply_stats = {

--- a/common/units/equipment/modules/00_ship_modules.txt
+++ b/common/units/equipment/modules/00_ship_modules.txt
@@ -1350,6 +1350,7 @@ equipment_modules = {
 
 		add_stats = {
 			torpedo_attack = 20
+			naval_torpedo_hit_chance_factor = 0.05
 			build_cost_ic = 60
 		}
 		multiply_stats = {
@@ -1369,7 +1370,7 @@ equipment_modules = {
 
 		add_stats = {
 			torpedo_attack = 30
-			naval_torpedo_hit_chance_factor = 0.05
+			naval_torpedo_hit_chance_factor = 0.1
 			build_cost_ic = 130
 		}
 		multiply_stats = {
@@ -1396,7 +1397,7 @@ equipment_modules = {
 
 		add_stats = {
 			torpedo_attack = 35
-			naval_torpedo_hit_chance_factor = 0.075
+			naval_torpedo_hit_chance_factor = 0.15
 			build_cost_ic = 165
 		}
 		multiply_stats = {
@@ -1420,7 +1421,7 @@ equipment_modules = {
 
 		add_stats = {
 			torpedo_attack = 40
-			naval_torpedo_hit_chance_factor = 0.1
+			naval_torpedo_hit_chance_factor = 0.20
 			build_cost_ic = 200
 		}
 		multiply_stats = {


### PR DESCRIPTION
Missions that do not require taking any risks should not give nearly as much supremacy as the missions that do. A navy afk in its fort on naval invasion support or strike force is not taking any risk what so ever and should not be rewarded with bonus supremacy. Using patrol and control escort missions should be rewarded as the fleet has to take a risk and be active in the zone, making it possible to attack it, so it should be the missions that are encouraged and rewarded in order to get more supremacy in a sea zone