### PR TITLE
Flame tanks

### DIFF
--- a/common/units/equipment/x_tank_chassis.txt
+++ b/common/units/equipment/x_tank_chassis.txt
@@ -3096,6 +3096,113 @@ equipments = {
 		}
 
 	}
+	
+	
+	### Flame Tank Equipment ###
+	
+	light_tank_flame_equipment_1940 = {
+		year = 1940
+		archetype = light_tank_chassis
+		parent = light_tank_equipment_1938
+		priority = 50
+		visual_level = 1
+		is_convertable = yes
+		
+		#Misc Abilities
+		maximum_speed = 8.1
+		reliability = 0.75
+		build_cost_ic = 16
+		fuel_consumption = 2.7
+		
+		#Defensive Abilities
+		defense = 10
+		breakthrough = 40
+		hardness = 0.65
+		armor_value = 29
+
+		#Offensive Abilities
+		soft_attack = 16
+		hard_attack = 8
+		ap_attack = 18	
+
+ 		#Space taken in convoy
+ 		lend_lease_cost = 8
+
+ 		resources = {
+ 			steel = 3
+ 			tungsten = 1
+ 		}
+
+	}
+	
+	medium_tank_flame_equipment_1940 = {
+	    year = 1940
+		archetype = medium_tank_chassis
+		parent = medium_tank_equipment_1938
+		priority = 50
+		visual_level = 1
+
+		
+	    #Misc Abilities
+		maximum_speed = 6.6
+		reliability = 0.73
+		build_cost_ic = 34
+		fuel_consumption = 4.0
+
+		#Defensive Abilities
+		defense = 6
+		breakthrough = 48
+		armor_value = 65
+		hardness = 0.8
+
+		#Offensive Abilities
+		soft_attack = 20
+		hard_attack = 12
+		ap_attack = 30
+
+		lend_lease_cost = 10
+
+		resources = {
+			steel = 4
+			tungsten = 1
+			chromium = 1
+		}
+	}
+	
+	heavy_tank_flame_equipment_1939 = {
+		archetype = heavy_tank_chassis
+		parent = heavy_tank_equipment_1934
+		parent = heavy_tank_equipment_1937
+		priority = 90
+		visual_level = 1
+		year = 1941
+		is_convertable = yes
+		
+		#Misc Abilities
+		maximum_speed = 4.8
+		reliability = 0.63
+		build_cost_ic = 54
+		fuel_consumption = 4.8
+		
+		#Defensive Abilities
+		hardness = 0.9
+		defense = 8
+		breakthrough = 56
+		armor_value = 95
+
+		#Offensive Abilities
+		soft_attack = 25
+		hard_attack = 15
+		ap_attack = 40
+
+		lend_lease_cost = 12
+
+		resources = {
+			steel = 5
+			tungsten = 1
+			chromium = 2
+		}
+	}
 
 	amphibious_tank_equipment_1 = {
 		year = 1939

--- a/common/units/flame_tank.txt
+++ b/common/units/flame_tank.txt
@@ -35,7 +35,7 @@ sub_units = {
 		#Misc Abilities
 		weight = 0.1
 		supply_consumption = 0.02
-		can_be_parachuted = yes
+		can_be_parachuted = no
 
 		soft_attack = -0.5
 		hard_attack = -0.5
@@ -117,7 +117,7 @@ sub_units = {
 		#Misc Abilities
 		weight = 0.1
 		supply_consumption = 0.025
-		can_be_parachuted = yes
+		can_be_parachuted = no
 
 		soft_attack = -0.6
 		hard_attack = -0.6
@@ -199,7 +199,7 @@ sub_units = {
 		#Misc Abilities
 		weight = 0.1
 		supply_consumption = 0.03
-		can_be_parachuted = yes
+		can_be_parachuted = no
 
 		soft_attack = -0.8
 		hard_attack = -0.8


### PR DESCRIPTION
Groundwork for Flame Tank additions

1. Probably only 2 types, light or medium tanks (but adding other stuff in case we expand), stats will be low
2. '39/'40 tech that unlocks when you research tank tech
3. Will be support company option only for now.
4. terrain modifiers will target forests and forts

Adding another support company option will further create strategic choices on premium support slots in divisions.