### PR TITLE
Air/Armor Tech Stealing Hotfix

### DIFF
--- a/common/operations/00_operations.txt
+++ b/common/operations/00_operations.txt
@@ -2550,7 +2550,7 @@ operation_steal_tech_armour = { ### 17 3/55
 		ROOT = {
 			add_tech_bonus = {
 				category = all_armour
-				bonus = 5
+				bonus = 0.5
 				name = operation_steal_tech_armour
 				uses = 1
 			}
@@ -2589,7 +2589,7 @@ operation_steal_tech_armour = { ### 17 3/55
 		ROOT = {
 			add_tech_bonus = {
 				category = all_armour
-				bonus = 5
+				bonus = 0.5
 				name = operation_steal_tech_armour
 				uses = 1
 			}
@@ -2926,7 +2926,7 @@ operation_steal_tech_airforce = { ### 19 3/55
 		ROOT = {
 			add_tech_bonus = {
 				category = all_air
-				bonus = 5
+				bonus = 0.5
 				name = operation_steal_tech_airforce
 				uses = 1
 			}


### PR DESCRIPTION
- Fixed a bug where some air/armor tech stealing would return a 500% instead of a 50% bonus