### PR TITLE
AAT Day 1 Hotfix

### DIFF
--- a/common/decisions/ENG.txt
+++ b/common/decisions/ENG.txt
@@ -2350,21 +2350,19 @@ operations = {
 		}
 		available = {
 			has_war = yes
-			AND = {
-				has_deployed_air_force_size = {
-					type = fighter
-					size < 1501
-				}
-				has_equipment = {
-					fighter_equipment < 1501
-				}
-				has_equipment = {
-					heavy_fighter_equipment < 1201
-				}
-			}
+			# num_deployed_planes_with_type@fighter
+			# num_equipment@small_plane_airframe
+			set_temp_variable = { ENG_air_var = num_deployed_planes_with_type@fighter }
+			add_to_temp_variable = { ENG_air_var = num_deployed_planes_with_type@heavy_fighter }
+			add_to_temp_variable = { ENG_air_var = num_equipment@small_plane_airframe }
+			add_to_temp_variable = { ENG_air_var = num_equipment@medium_plane_fighter_airframe }
+			check_variable = { ENG_air_var < 1500 }
 			NOT = {
 				has_idea = ENG_emergencyfighter
 			}
+		}
+		visible = {
+			always = yes
 		}
 
 		cost = 25
@@ -2373,21 +2371,6 @@ operations = {
 			factor = 1
 		}
         fire_only_once = yes
-		visible = {
-			has_war = yes
-			AND = {
-				has_deployed_air_force_size = {
-					type = fighter
-					size < 1500
-				}
-				has_equipment = {
-					fighter_equipment < 1500
-				}
-			}
-			NOT = {
-				has_idea = ENG_emergencyfighter
-			}
-		}
 
 		complete_effect = {
 			add_timed_idea = { idea = ENG_emergencyfighter days = 180 }

--- a/common/decisions/ENG.txt
+++ b/common/decisions/ENG.txt
@@ -2346,23 +2346,20 @@ operations = {
 
 		allowed = {
 			tag = ENG
-			always = yes
-		}
-		available = {
-			has_war = yes
-			# num_deployed_planes_with_type@fighter
-			# num_equipment@small_plane_airframe
-			set_temp_variable = { ENG_air_var = num_deployed_planes_with_type@fighter }
-			add_to_temp_variable = { ENG_air_var = num_deployed_planes_with_type@heavy_fighter }
-			add_to_temp_variable = { ENG_air_var = num_equipment@small_plane_airframe }
-			add_to_temp_variable = { ENG_air_var = num_equipment@medium_plane_fighter_airframe }
-			check_variable = { ENG_air_var < 1500 }
-			NOT = {
-				has_idea = ENG_emergencyfighter
-			}
 		}
 		visible = {
-			always = yes
+			has_war = yes
+		}
+		available = {
+			set_temp_variable = { ENG_air_var = num_deployed_planes_with_type@small_plane_airframe }
+			add_to_temp_variable = { ENG_air_var = num_deployed_planes_with_type@medium_plane_fighter_airframe }
+			add_to_temp_variable = { ENG_air_var = num_equipment@small_plane_airframe }
+			add_to_temp_variable = { ENG_air_var = num_equipment@medium_plane_fighter_airframe }
+			has_war = yes
+			custom_trigger_tooltip = {
+				tooltip = less_than_1500_fighter_heavy_tt
+				check_variable = { ENG_air_var < 1500 }
+			}
 		}
 
 		cost = 25

--- a/common/decisions/FRA.txt
+++ b/common/decisions/FRA.txt
@@ -477,6 +477,23 @@ economy_decisions = {
 					instant_build = yes
 				}
 			}
+			IF = {
+				limit = {
+					has_dlc = "Arms Against Tyranny"
+				}
+				mio:FRA_amiot_organization = {
+					set_mio_name_key = SNCAN
+					add_mio_research_bonus = -0.02
+					add_mio_funds_gain_factor = 0.05
+					
+				}
+				hidden_effect = {
+					mio:FRA_amiot_organization = {
+						set_mio_icon = GFX_idea_FRA_sncan
+					}
+				}
+
+			}
 		}
 		days_remove = 90
 		cost = 40
@@ -556,6 +573,23 @@ economy_decisions = {
 					instant_build = yes
 				}
 			}
+			IF = {
+				limit = {
+					has_dlc = "Arms Against Tyranny"
+				}
+				mio:FRA_bloch_organization = {
+					set_mio_name_key = SNCAN
+					add_mio_research_bonus = -0.02
+					add_mio_funds_gain_factor = 0.05
+					
+				}
+				hidden_effect = {
+					mio:FRA_bloch_organization = {
+						set_mio_icon = GFX_idea_FRA_sncao
+					}
+				}
+
+			}
 		}
 		days_remove = 90
 		cost = 40
@@ -632,6 +666,18 @@ economy_decisions = {
 					type = arms_factory
 					level = 1
 					instant_build = yes
+				}
+			}
+			IF = {
+				limit = {
+					has_dlc = "Arms Against Tyranny"
+				}
+				custom_effect_tooltip = invites_mio_tt
+				show_mio_tooltip = FRA_SNCAC_organization
+				mio:FRA_SNCAC_organization = {
+					add_mio_size = 2
+					add_mio_research_bonus = -0.02
+					add_mio_funds_gain_factor = 0.05
 				}
 			}
 		}
@@ -712,6 +758,23 @@ economy_decisions = {
 					instant_build = yes
 				}
 			}
+			IF = {
+				limit = {
+					has_dlc = "Arms Against Tyranny"
+				}
+				mio:FRA_morane_saulnier_organization = {
+					set_mio_name_key = SNCAN
+					add_mio_research_bonus = -0.02
+					add_mio_funds_gain_factor = 0.05
+					
+				}
+				hidden_effect = {
+					mio:FRA_morane_saulnier_organization = {
+						set_mio_icon = GFX_idea_FRA_sncase
+					}
+				}
+
+			}
 		}
 		days_remove = 90
 		cost = 40
@@ -789,6 +852,23 @@ economy_decisions = {
 					level = 1
 					instant_build = yes
 				}
+			}
+			IF = {
+				limit = {
+					has_dlc = "Arms Against Tyranny"
+				}
+				mio:FRA_levasseur_organization = {
+					set_mio_name_key = SNCAN
+					add_mio_research_bonus = -0.02
+					add_mio_funds_gain_factor = 0.05
+					
+				}
+				hidden_effect = {
+					mio:FRA_levasseur_organization = {
+						set_mio_icon = GFX_idea_FRA_sncaso
+					}
+				}
+
 			}
 		}
 		days_remove = 90

--- a/common/decisions/GER.txt
+++ b/common/decisions/GER.txt
@@ -5192,50 +5192,30 @@ GER_military_buildup = {
 
 		icon = generic_air
 
-		available = {
+		allowed = {
+			tag = GER
+		}
+		visible = {
 			has_war = yes
-			AND = {
-				has_deployed_air_force_size = {
-					type = fighter
-					size < 1501
-				}
-				has_equipment = {
-					small_plane_airframe < 1501
-				}
-			}
-			NOT = {
-				has_idea = GER_jaegernotprogramm
+		}
+		available = {
+			set_temp_variable = { GER_air_var = num_deployed_planes_with_type@small_plane_airframe }
+			add_to_temp_variable = { GER_air_var = num_deployed_planes_with_type@medium_plane_fighter_airframe }
+			add_to_temp_variable = { GER_air_var = num_equipment@small_plane_airframe }
+			add_to_temp_variable = { GER_air_var = num_equipment@medium_plane_fighter_airframe }
+			has_war = yes
+			custom_trigger_tooltip = {
+				tooltip = less_than_1500_fighter_heavy_tt
+				check_variable = { GER_air_var < 1500 }
 			}
 		}
 
         fire_only_once = yes
 
-		visible = {
-			has_war = yes
-			AND = {
-				has_deployed_air_force_size = {
-					type = fighter
-					size < 1501
-				}
-				has_equipment = {
-					small_plane_airframe < 1501
-				}
-			}
-			NOT = {
-				has_idea = GER_jaegernotprogramm
-			}
-		}
-
 		cost = 25
 
 		ai_will_do = {
 			factor = 1
-		}
-
-		visible = {
-			NOT = {
-				has_idea = GER_jaegernotprogramm
-			}
 		}
 
 		complete_effect = {

--- a/common/defines/00_defines.lua
+++ b/common/defines/00_defines.lua
@@ -641,7 +641,7 @@ NProduction = {
 	SHIP_REFIT_MAX_PROGRESS_TO_CANCEL = 0.2,			-- Maximum refitting progress % that we still allow to cancel wihtout having to scuttle the ship.
 	SHIP_REFIT_DAMAGE_TO_PROGRESS_FACTOR = 0.5,			-- When a ship is being damaged (for example port strike) while refitting, the damage is transferred to the production line progress instead. This variable is used to balance it.
 	MINIMUM_NUMBER_OF_FACTORIES_TAKEN_BY_CONSUMER_GOODS_VALUE = 1,		-- The minimum number of factories we have to put on consumer goods, by value.
-	MINIMUM_NUMBER_OF_FACTORIES_TAKEN_BY_CONSUMER_GOODS_PERCENT = 0.1,	-- The minimum number of factories we have to put on consumer goods, in percent.
+	MINIMUM_NUMBER_OF_FACTORIES_TAKEN_BY_CONSUMER_GOODS_PERCENT = 0.01,	-- The minimum number of factories we have to put on consumer goods, in percent.
 	
 },
 

--- a/common/defines/00_defines.lua
+++ b/common/defines/00_defines.lua
@@ -22,6 +22,7 @@ NGame = {
 	MAX_SCRIPTED_LOC_RECURSION = 30,				-- max recursion for scripted localizations
 	HANDS_OFF_START_TAG = "TUR",					-- tag for player country for -hands_off runs. use an existing tag that is less likely to affect the game
 	ALERT_SFX_COOLDOWN_DAYS = 14,					-- After playing an alert sound, don't play the same sound for XXX days, even if it fires again.
+	MUSIC_PLAYER_RECENTLY_PLAYED_SIZE = 10,			-- The music player keeps track of recently played music to try and avoid playing the same songs too often. This determines the max number of songs in the recently played list.
 },
 
 NDiplomacy = {
@@ -2147,6 +2148,7 @@ NAI = {
 	EQUIPMENT_MARKET_DEFAULT_CIC_CHUNK_FOR_SALE = 150.0,            -- When putting things up for sale on the market, this determines the default "chunk" size of equipment the AI puts up. Gets overridden by equipment_market_min_for_sale AI strategy. (If one equipment is worth 5 CIC, a value of 150 would result in chunk sizes of 150/5 = 30 units)
 	EQUIPMENT_MARKET_NR_DELIVERIES_SOFT_MAX = 10,                   -- AI tries to adjust assigned factories and amount of equipment to keep nr deliveries at max this
 	EQUIPMENT_MARKET_EXTRA_CONVOYS_OVERRIDE = 2,                    -- Makes the AI able to buy convoys even if they are lacking free convoys. 0 will make them stop this behavior, anything > 0 will allow overriding the perceived nr of free convoys. Only if convoy equipment has a non-zero weight does the actual value matter.
+	EQUIPMENT_MARKET_WANTED_CONVOY_USAGE_RATIO = 0.3,               -- If the AI's available/free/unused convoys is reduced to this ratio (0.3 = 30 %), start buying convoys.
 	EQUIPMENT_MARKET_CONTRACT_DURATION_ACCEPTANCE = -10,            -- If expected contract duration is longer than EQUIPMENT_MARKET_NR_DELIVERIES_SOFT_MAX deliveries, then add this to the PurchaseContract AI acceptance score per nr overdue deliveries
 	EQUIPMENT_MARKET_CONTRACT_EFFICIENCY_TO_CANCEL = 0.1,           -- If contract efficiency stays below this, the AI will cancel the contract
 	EQUIPMENT_MARKET_EQUIPMENT_SUNK_TO_CANCEL = 0.5,                -- If more equipment is sunk then the given percentage, the AI will cancel the contract
@@ -4073,8 +4075,9 @@ NAITheatre = {
 NIndustrialOrganisation = {
 	ASSIGN_DESIGN_TEAM_PP_COST_PER_DAY = 0.1,					-- Cost in Political Power daily generation when one MIO is assigned to a research slot
 	ASSIGN_INDUSTRIAL_MANUFACTURER_PP_COST_PER_DAY = 0.0,		-- Cost in Political Power daily generation when one MIO is assigned to a production line
-	FUNDS_FOR_SIZE_UP = 1000,					-- Funds needed for a MIO to increment its size and get points to unlock traits
-	FUNDS_FOR_SIZE_UP_LEVEL_FACTOR = 0.8, 			-- How much each level mutliplies the funds for size up 
+	FUNDS_FOR_SIZE_UP = 700,					-- Funds needed for a MIO to increment its size and get points to unlock traits
+	FUNDS_FOR_SIZE_UP_LEVEL_FACTOR = 100, 			-- How much each level mutliplies the funds for size up 
+	FUNDS_FOR_SIZE_UP_LEVEL_POW = 1.8, 							-- the power we applie to the mio size when calculating funds to level up. 	
 	UNLOCKED_TRAITS_PER_SIZE_UP = 1,			-- Number of points for unlocking traits obtained when the MIO increments its size
 	DESIGN_TEAM_CHANGE_XP_COST = 5,				-- Flat cost added to the XP cost of a new equipment design
 	FUNDS_FOR_RESEARCH_COMPLETION_PER_RESEARCH_COST = 250,     -- Funds added to MIO when the Design Team has completed a research, multiplied by research_cost in technology template

--- a/common/ideas/GER.txt
+++ b/common/ideas/GER.txt
@@ -863,6 +863,9 @@ ideas = {
 				small_plane_airframe = {
 					build_cost_ic = -0.25 instant = yes
 				}
+				medium_plane_fighter_airframe = {
+					build_cost_ic = -0.25 instant = yes
+				}
 				small_plane_cas_airframe = {
 					build_cost_ic = 0.15 instant = yes
 				}

--- a/common/ideas/usa.txt
+++ b/common/ideas/usa.txt
@@ -670,6 +670,7 @@ ideas = {
 
 			modifier = {
 				consumer_goods_factor = 0.2
+				industrial_capacity_dockyard = 0.1
 			}
 		}
 

--- a/common/military_industrial_organization/organizations/00_generic_organization.txt
+++ b/common/military_industrial_organization/organizations/00_generic_organization.txt
@@ -7308,7 +7308,7 @@ generic_motorized_mechanized_organization = {
 	icon = GFX_idea_generic_motorized_equipment_manufacturer_3
 
 	allowed = {
-		NOT = { OR = { tag = GER tag = ENG tag = CAN tag = SAF tag = SOV tag = FRA tag = ITA tag = JAP tag = USA tag = CZE tag = ROM tag = MEX } }
+		NOT = { OR = { tag = GER tag = ENG tag = CAN tag = SAF tag = AST tag = SOV tag = FRA tag = ITA tag = JAP tag = USA tag = CZE tag = ROM tag = MEX } }
 		NOT = {
 			AND = {
 				tag = POL

--- a/common/military_industrial_organization/organizations/00_generic_organization.txt
+++ b/common/military_industrial_organization/organizations/00_generic_organization.txt
@@ -5748,7 +5748,7 @@ generic_high_agility_fighter_aircraft_organization = {
 
 		equipment_bonus = {
 			air_agility = 0.10
-			air_range = -0.10
+			air_range = 0.10
 		}
 	}
 

--- a/common/military_industrial_organization/organizations/00_generic_organization.txt
+++ b/common/military_industrial_organization/organizations/00_generic_organization.txt
@@ -4831,7 +4831,10 @@ generic_cas_aircraft_organization = {
 	icon = GFX_idea_generic_air_manufacturer_1
 
 	allowed = {
-		always = no # Archetype only - countries using it have their own verisons
+		OR = {
+			tag = FRA
+			tag = SOV
+		}
 	}
 
 	equipment_type = {

--- a/common/military_industrial_organization/organizations/00_generic_organization.txt
+++ b/common/military_industrial_organization/organizations/00_generic_organization.txt
@@ -7308,7 +7308,7 @@ generic_motorized_mechanized_organization = {
 	icon = GFX_idea_generic_motorized_equipment_manufacturer_3
 
 	allowed = {
-		NOT = { OR = { tag = GER tag = ENG tag = SOV tag = FRA tag = ITA tag = JAP tag = USA tag = CZE tag = ROM tag = MEX } }
+		NOT = { OR = { tag = GER tag = ENG tag = CAN tag = SAF tag = SOV tag = FRA tag = ITA tag = JAP tag = USA tag = CZE tag = ROM tag = MEX } }
 		NOT = {
 			AND = {
 				tag = POL

--- a/common/military_industrial_organization/organizations/00_generic_organization.txt
+++ b/common/military_industrial_organization/organizations/00_generic_organization.txt
@@ -4832,7 +4832,6 @@ generic_cas_aircraft_organization = {
 
 	allowed = {
 		OR = {
-			tag = FRA
 			tag = SOV
 		}
 	}

--- a/common/military_industrial_organization/organizations/CHI_organization.txt
+++ b/common/military_industrial_organization/organizations/CHI_organization.txt
@@ -49,9 +49,6 @@ CHI_jiangnan_shipyard_group_organization = {
 		} 
 		has_dlc = "Waking the Tiger"
 	}
-	available = {
-		owner = { controls_state = 608 }
-	}
 }
 
 CHI_dagu_shipyard_organization = {

--- a/common/military_industrial_organization/organizations/CHI_organization.txt
+++ b/common/military_industrial_organization/organizations/CHI_organization.txt
@@ -50,7 +50,7 @@ CHI_jiangnan_shipyard_group_organization = {
 		has_dlc = "Waking the Tiger"
 	}
 	available = {
-		owner = { controls_state = 613 }
+		owner = { controls_state = 608 }
 	}
 }
 
@@ -64,9 +64,6 @@ CHI_dagu_shipyard_organization = {
 			tag = MEN
 		} 
 		has_dlc = "Waking the Tiger"
-	}
-	available = {
-		owner = { controls_state = 608 }
 	}
 }
 
@@ -94,8 +91,6 @@ CHI_camco_medium_organization = {
 	allowed = {	
 		OR = {
 			is_literally_china = yes
-			tag = MAN
-			tag = MEN
 		} 
 		has_dlc = "Waking the Tiger"
 	}
@@ -109,8 +104,6 @@ CHI_camco_fighter_organization = {
 	allowed = {	
 		OR = {
 			is_literally_china = yes
-			tag = MAN
-			tag = MEN
 		} 
 		has_dlc = "Waking the Tiger"
 	}
@@ -124,8 +117,6 @@ CHI_camco_bomber_organization = {
 	allowed = {	
 		OR = {
 			is_literally_china = yes
-			tag = MAN
-			tag = MEN
 		} 
 		has_dlc = "Waking the Tiger"
 	}
@@ -156,23 +147,16 @@ CHI_taiyuan_arsenal_organization = {
 		} 
 		has_dlc = "Waking the Tiger"
 	}
-	available = {
-		owner = { controls_state = 615 }
-	}
 }
 CHI_liaoning_arsenal_organization = {
 	include = generic_motorized_mechanized_organization
 	icon = GFX_idea_generic_motorized_equipment_manufacturer_1
 	allowed = {	
 		OR = {
-			is_literally_china = yes
 			tag = MAN
 			tag = MEN
 		} 
 		has_dlc = "Waking the Tiger"
-	}
-	available = {
-		owner = { controls_state = 715 }
 	}
 }
 CHI_hanyan_arsenal_organization = {
@@ -181,8 +165,6 @@ CHI_hanyan_arsenal_organization = {
 	allowed = {	
 		OR = {
 			is_literally_china = yes
-			tag = MAN
-			tag = MEN
 		} 
 		has_dlc = "Waking the Tiger"
 	}
@@ -195,13 +177,9 @@ CHI_mukden_arsenal_organization = {
 	icon = GFX_idea_generic_infantry_equipment_manufacturer_2
 	allowed = {	
 		OR = {
-			is_literally_china = yes
 			tag = MAN
 			tag = MEN
 		} 
 		has_dlc = "Waking the Tiger"
-	}
-	available = {
-		owner = { controls_state = 716 }
 	}
 }

--- a/common/military_industrial_organization/organizations/ENG_organization.txt
+++ b/common/military_industrial_organization/organizations/ENG_organization.txt
@@ -73,8 +73,6 @@ ENG_vauxhall_organization = {
 			tag = SAF
 			tag = CAN
 			tag = AST
-			tag = NZL
-			tag = IRE
 		}
 	}
 
@@ -585,6 +583,7 @@ ENG_vauxhall_automotive_organization = {
 		OR = {
 			tag = ENG
 			tag = CAN
+			tag = AST
 		}
 	}
 	
@@ -603,8 +602,6 @@ ENG_royal_arsenal_organization = {
 			tag = ENG
 			tag = CAN
 			tag = AST
-			tag = NZL
-			tag = IRE
 		}
 	}
 }

--- a/common/military_industrial_organization/organizations/ENG_organization.txt
+++ b/common/military_industrial_organization/organizations/ENG_organization.txt
@@ -12,64 +12,7 @@ ENG_vickers_armstrong_eng_organization = {
 	icon = GFX_idea_vickers_armstrong_eng
 	
 	allowed = {	
-		OR = {
-			tag = ENG 
-			AND = {
-				tag = GRE
-				has_dlc = "Battle for the Bosporus"
-			}
-			AND = {
-				tag = BUL
-				has_dlc = "Battle for the Bosporus"
-			}
-			AND = {
-				tag = ETH 
-				has_dlc = "By Blood Alone"
-			}
-		}
-	}
-
-	visible = {
-#		IF = {
-#			limit = { FROM = { original_tag = ETH } }
-#			FROM = { has_completed_focus = ETH_invite_foreign_industrialists }
-#		}
-	}
-	
-	available = {
-		# When in a Foreign MIO, countries need to be at peace with original country
-		IF = {
-			limit = {
-				FROM = { NOT = { original_tag = ENG } }
-			}
-			FROM = { NOT = { has_war_with = ENG } }
-		}
-
-		IF = {
-			limit = { 
-				OR = { 
-					FROM = { original_tag = BUL }
-					FROM = { original_tag = ETH }
-				}  
-			}
-			custom_trigger_tooltip = {
-				tooltip = has_invited_mio_tt
-				FROM = {
-					has_country_flag = has_invited_vickers_mio_flag 
-				}
-			}
-		}
-		IF = {
-			limit = { FROM = { original_tag = BUL } } 
-			FROM = {
-				OR = {
-					is_subject = no
-					is_subject_of = ENG
-				}
-				#is_in_faction_with = ENG
-				NOT = { has_completed_focus = BUL_nationalization }
-			}
-		}
+		tag = ENG
 	}
 
 	initial_trait = {
@@ -127,74 +70,11 @@ ENG_vauxhall_organization = {
 	allowed = {	
 		OR = {
 			tag = ENG
-			AND = {
-				tag = POL # If Poland sets up a local one
-				OR = {
-					has_dlc = "Poland: United and Ready"
-					has_dlc = "No Step Back"
-				}
-			}
-			AND = {
-				tag = BUL
-				has_dlc = "Battle for the Bosporus"
-			}
-			AND = {
-				tag = ETH 
-				has_dlc = "By Blood Alone"
-			}
-		}
-	}
-
-	visible = {
-		IF = { 
-			limit = {
-				FROM = { original_tag = POL }
-			}
-			FROM = {
-				has_country_flag = POL_vauxhall_motors
-#				NOT = { has_completed_focus = POL_adaptive_designs }
-			}
-		}
-		IF = {
-			limit = { FROM = { original_tag = ETH } }
-#			FROM = { has_completed_focus = ETH_invite_foreign_industrialists }
-		}
-	
-	}
-
-	available = {
-		# When in a Foreign MIO, countries need to be at peace with original country
-		IF = {
-			limit = {
-				FROM = { NOT = { original_tag = ENG } }
-			}
-			FROM = { NOT = { has_war_with = ENG } }
-		}
-
-		IF = {
-			limit = { 
-				OR = { 
-					FROM = { original_tag = BUL }
-					FROM = { original_tag = ETH }
-				}  
-			}
-			custom_trigger_tooltip = {
-				tooltip = has_invited_mio_tt
-				FROM = {
-					has_country_flag = has_invited_vauxhall_mio_flag 
-				}
-			}
-		}
-		IF = {
-			limit = { FROM = { original_tag = BUL } } 
-			FROM = {
-				OR = {
-					is_subject = no
-					is_subject_of = ENG
-				}
-				#is_in_faction_with = ENG
-				NOT = { has_completed_focus = BUL_nationalization }
-			}
+			tag = SAF
+			tag = CAN
+			tag = AST
+			tag = NZL
+			tag = IRE
 		}
 	}
 
@@ -704,76 +584,8 @@ ENG_vauxhall_automotive_organization = {
 	allowed = {	
 		OR = {
 			tag = ENG
-			tag = POL # If Poland sets up a local one
-			AND = {
-				tag = ROM
-				has_dlc = "Death or Dishonor"
-			}
-			AND = {
-				tag = BUL
-				has_dlc = "Battle for the Bosporus"
-			}
-			AND = {
-				tag = ETH 
-				has_dlc = "By Blood Alone"
-			}
+			tag = CAN
 		}
-	}
-	
-	visible = {
-		IF = { 
-			limit = {
-				FROM = { original_tag = POL }
-			}
-			FROM = {
-				has_country_flag = POL_vauxhall_motors
-#				NOT = { has_completed_focus = POL_adaptive_designs }
-			}
-		}
-		IF = {
-			limit = { FROM = { original_tag = ETH } }
-#			FROM = { has_completed_focus = ETH_invite_foreign_industrialists }
-		}	
-	}
-	
-	available = {
-		# When in a Foreign MIO, countries need to be at peace with original country
-		IF = {
-			limit = {
-				FROM = { NOT = { original_tag = ENG } }
-			}
-			FROM = { NOT = { has_war_with = ENG } }
-		}
-
-		IF = {
-			limit = {
-				OR = { 
-					FROM = { original_tag = BUL }
-					FROM = { original_tag = ETH }
-				}  
-			}
-			custom_trigger_tooltip = {
-				tooltip = has_invited_mio_tt
-				FROM = {
-					has_country_flag = has_invited_vauxhall_mio_flag 
-				}
-			}
-		}
-		IF = {
-			limit = { FROM = { original_tag = BUL } }
-			FROM = {
-				OR = {
-					is_subject = no
-					is_subject_of = ENG
-				}
-				#is_in_faction_with = ENG
-				NOT = { has_completed_focus = BUL_nationalization }
-			}
-		}
-		IF = {
-			limit = { FROM = { original_tag = ROM } }
-			FROM = { has_country_flag = ENG_mot_chosen }
-		}	
 	}
 	
 	initial_trait = {
@@ -789,40 +601,10 @@ ENG_royal_arsenal_organization = {
 	allowed = {
 		OR = {
 			tag = ENG
-			AND = {
-				OR = {
-					original_TAG = LAT
-					original_TAG = LIT
-					original_TAG = EST
-				}
-				has_dlc = "No Step Back"
-			}
-		}
-	}
-
-	available = {
-		# When in a Foreign MIO, countries need to be at peace with original country
-		IF = {
-			limit = {
-				FROM = { NOT = { original_tag = ENG } }
-			}
-			FROM = { NOT = { has_war_with = ENG } }
-		}
-
-		if = {
-			limit = {
-				FROM = {
-					OR = {
-						original_TAG = LAT
-						original_TAG = LIT
-						original_TAG = EST
-					}
-				}
-			}
-			FROM = {
-
-#				has_completed_focus = BALTIC_british_designers
-			}
+			tag = CAN
+			tag = AST
+			tag = NZL
+			tag = IRE
 		}
 	}
 }

--- a/common/military_industrial_organization/organizations/JAP_organization.txt
+++ b/common/military_industrial_organization/organizations/JAP_organization.txt
@@ -36,11 +36,6 @@ JAP_kure_naval_arsenal_organization = {
 		tag = JAP
 		has_dlc = "Arms Against Tyranny"
 	}
-	available = {
-		FROM = {
-			has_completed_focus = JAP_activate_the_arsenals
-		}
-	}
 }
 
 JAP_yokosuka_naval_arsenal_organization = {
@@ -49,11 +44,6 @@ JAP_yokosuka_naval_arsenal_organization = {
 	allowed = {	
 		tag = JAP
 		has_dlc = "Arms Against Tyranny"
-	}
-	available = {
-		FROM = {
-			has_completed_focus = JAP_activate_the_arsenals
-		}
 	}
 }
 

--- a/common/military_industrial_organization/organizations/MAN_organization.txt
+++ b/common/military_industrial_organization/organizations/MAN_organization.txt
@@ -39,10 +39,6 @@ MAN_mamc_organization = {
 		original_tag = MAN
 		NOT = { has_dlc = "Waking the Tiger" }
 	}
-
-	available = {
-		owner = { controls_state = 714 }
-	}
 }
 
 MAN_mamc_light_organization = {
@@ -51,10 +47,6 @@ MAN_mamc_light_organization = {
 	allowed = {	
 		original_tag = MAN
 		has_dlc = "Waking the Tiger"
-	}
-
-	available = {
-		owner = { has_completed_focus = MAN_mamc }
 	}
 }
 
@@ -65,10 +57,6 @@ MAN_mamc_medium_organization = {
 		original_tag = MAN
 		has_dlc = "Waking the Tiger"
 	}
-
-	available = {
-		owner = { has_completed_focus = MAN_mamc }
-	}
 }
 
 MAN_mamc_heavy_organization = {
@@ -77,10 +65,6 @@ MAN_mamc_heavy_organization = {
 	allowed = {	
 		original_tag = MAN
 		has_dlc = "Waking the Tiger"
-	}
-
-	available = {
-		owner = { has_completed_focus = MAN_mamc }
 	}
 }
 

--- a/common/military_industrial_organization/organizations/SAF_organization.txt
+++ b/common/military_industrial_organization/organizations/SAF_organization.txt
@@ -15,11 +15,6 @@ SAF_marmon_herrington_organization = {
     allowed = {
         original_tag = SAF
     }
-    available = {
-        owner = {
-            has_completed_focus = SAF_the_sarc_mki
-        }
-    }
 }
 SAF_iscor_organization = {
     name = SAF_iscor_organization
@@ -28,11 +23,6 @@ SAF_iscor_organization = {
     allowed = {
         original_TAG = SAF
         has_dlc = "Together for Victory"
-    }
-    available = {
-        owner = {
-            has_completed_focus = SAF_south_african_steel
-        }
     }
 }
 
@@ -79,11 +69,6 @@ SAF_pretoria_royal_mint_organization = {
     allowed = {
         original_tag = SAF
     }
-    available = {
-        owner = {
-            has_completed_focus = SAF_retool_pretoria_mint
-        }
-    }
 }
 
 SAF_pretoria_metal_pressings_organization = {
@@ -92,11 +77,6 @@ SAF_pretoria_metal_pressings_organization = {
     icon = GFX_idea_generic_artillery_manufacturer_1
     allowed = {
         original_tag = SAF
-    }
-    available = {
-        owner = {
-            has_completed_focus = SAF_pretoria_metal_pressings
-        }
     }
 }
 

--- a/common/national_focus/japan.txt
+++ b/common/national_focus/japan.txt
@@ -3498,13 +3498,9 @@ focus_tree = {
 		completion_reward = {
 			if = {
 				limit = { has_dlc = "Arms Against Tyranny" }
-				custom_effect_tooltip = available_mio_tt
-				show_mio_tooltip  = JAP_kure_naval_arsenal_organization
 				mio:JAP_kure_naval_arsenal_organization = {
 					add_mio_funds = 800
 				}
-				custom_effect_tooltip = available_mio_tt
-				show_mio_tooltip  = JAP_yokosuka_naval_arsenal_organization
 				mio:JAP_yokosuka_naval_arsenal_organization = {
 					add_mio_funds = 800
 				}
@@ -3924,8 +3920,12 @@ focus_tree = {
 	focus = {
 		id = JAP_fighter_modernization
 		icon = GFX_goal_generic_build_airforce
+		prerequisite = {
+			focus = JAP_range_focus
+			focus = JAP_agility_focus
+		}
 		x = 1
-		y = 1
+		y = 2
 		relative_position_id = JAP_jungle_fighting_techniques
 
 		cost = 5
@@ -3952,9 +3952,8 @@ focus_tree = {
 	focus = {
 		id = JAP_range_focus
 		icon = GFX_idea_aichi
-		prerequisite = { focus = JAP_fighter_modernization }
 		x = -1
-		y = 1
+		y = -1
 		relative_position_id = JAP_fighter_modernization
 		mutually_exclusive = { focus = JAP_agility_focus }
 
@@ -3974,7 +3973,7 @@ focus_tree = {
 				custom_effect_tooltip = available_mio_tt
 				show_mio_tooltip = JAP_aichi_organization
 				mio:JAP_aichi_organization = {
-					add_mio_funds = 1500
+					add_mio_funds = 1600
 				}
 			}
 			else_if = {
@@ -3992,7 +3991,7 @@ focus_tree = {
 				custom_effect_tooltip = available_mio_tt
 				show_mio_tooltip = JAP_aichi_organization
 				mio:JAP_aichi_organization = {
-					add_mio_funds = 1500
+					add_mio_funds = 1600
 				}
 			}
 			else_if = {
@@ -4015,9 +4014,8 @@ focus_tree = {
 	focus = {
 		id = JAP_agility_focus
 		icon = GFX_idea_mitsubishi
-		prerequisite = { focus = JAP_fighter_modernization }
 		x = 1
-		y = 1
+		y = -1
 		relative_position_id = JAP_fighter_modernization
 		mutually_exclusive = { focus = JAP_range_focus }
 
@@ -4041,7 +4039,7 @@ focus_tree = {
 				custom_effect_tooltip = available_mio_tt
 				show_mio_tooltip = JAP_mitsubishi_organization
 				mio:JAP_mitsubishi_organization = {
-					add_mio_funds = 1500
+					add_mio_funds = 1600
 				}
 			}
 			else_if = {
@@ -4059,7 +4057,7 @@ focus_tree = {
 				custom_effect_tooltip = available_mio_tt
 				show_mio_tooltip = JAP_mitsubishi_organization
 				mio:JAP_mitsubishi_organization = {
-					add_mio_funds = 1500
+					add_mio_funds = 1600
 				}
 			}
 			else_if = {
@@ -4083,12 +4081,11 @@ focus_tree = {
 		id = JAP_strengthen_the_army_air_arm
 		icon = GFX_focus_usa_escort_fighters
 		prerequisite = {
-			focus = JAP_range_focus
-			focus = JAP_agility_focus
+			focus = JAP_fighter_modernization
 		}
 		mutually_exclusive = { focus = JAP_strengthen_the_fleet_air_arm }
 		x = 0
-		y = 1
+		y = 2
 		relative_position_id = JAP_range_focus
 
 		cost = 5
@@ -4134,12 +4131,11 @@ focus_tree = {
 		id = JAP_strengthen_the_fleet_air_arm
 		icon = GFX_goal_generic_air_naval_bomber
 		prerequisite = {
-			focus = JAP_range_focus
-			focus = JAP_agility_focus
+			focus = JAP_fighter_modernization
 		}
 		mutually_exclusive = { focus = JAP_strengthen_the_army_air_arm }
 		x = 0
-		y = 1
+		y = 2
 		relative_position_id = JAP_agility_focus
 
 		cost = 5

--- a/common/national_focus/south_africa.txt
+++ b/common/national_focus/south_africa.txt
@@ -1558,8 +1558,6 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_dlc = "Arms Against Tyranny" }
-				custom_effect_tooltip = available_mio_tt
-				show_mio_tooltip  = SAF_pretoria_royal_mint_organization
 				mio:SAF_pretoria_royal_mint_organization = {
 					add_mio_funds = 800
 				}
@@ -1607,8 +1605,6 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_dlc = "Arms Against Tyranny" }
-				custom_effect_tooltip = available_mio_tt
-				show_mio_tooltip  = SAF_pretoria_metal_pressings_organization
 				mio:SAF_pretoria_metal_pressings_organization = {
 					add_mio_funds = 800
 				}
@@ -1677,8 +1673,6 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_dlc = "Arms Against Tyranny" }
-				custom_effect_tooltip = available_mio_tt
-				show_mio_tooltip  = SAF_marmon_herrington_organization
 				mio:SAF_marmon_herrington_organization = {
 					add_mio_funds = 800
 				}
@@ -2634,8 +2628,6 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_dlc = "Arms Against Tyranny" }
-				custom_effect_tooltip = available_mio_tt
-				show_mio_tooltip  = SAF_iscor_organization
 				mio:SAF_iscor_organization = {
 					add_mio_funds = 800
 				}

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -1852,18 +1852,6 @@ focus_tree = {
 				idea = JAP_modernize_the_fleet
 				days = 365 
 			}
-			mio:USA_norfolk_naval_yard_organization = {
-				add_mio_funds = 2400
-			}
-			mio:USA_electric_boat_company_organization = {
-				add_mio_funds = 2400
-			}
-			mio:USA_brooklyn_naval_yard_organization = {
-				add_mio_funds = 2400
-			}
-			mio:USA_newport_news_shipbuilding_organization = {
-				add_mio_funds = 2400
-			}
 		}
 		
 		completion_reward = {
@@ -1942,18 +1930,6 @@ focus_tree = {
 			add_timed_idea = {
 				idea = JAP_modernize_the_fleet
 				days = 365 
-			}
-			mio:USA_norfolk_naval_yard_organization = {
-				add_mio_funds = 2400
-			}
-			mio:USA_electric_boat_company_organization = {
-				add_mio_funds = 2400
-			}
-			mio:USA_brooklyn_naval_yard_organization = {
-				add_mio_funds = 2400
-			}
-			mio:USA_newport_news_shipbuilding_organization = {
-				add_mio_funds = 2400
 			}
 		}
 	}					

--- a/common/units/equipment/ship_hull_carrier.txt
+++ b/common/units/equipment/ship_hull_carrier.txt
@@ -235,10 +235,7 @@ equipments = {
 				allowed_module_categories = { heavy_ship_engine carrier_ship_engine }
 			}
 			fixed_ship_secondaries_slot = inherit
-			fixed_ship_armor_slot = {
-				required = no
-				allowed_module_categories = { ship_heavy_armor ship_cruiser_armor }
-			}
+			fixed_ship_armor_slot = inherit
 			mid_1_custom_slot = {
 				required = no
 				allowed_module_categories = {

--- a/descriptor.mod
+++ b/descriptor.mod
@@ -10,5 +10,5 @@ tags={
 	"Balance"
 }
 name="Baptized Testing"
-supported_version="1.12.14"
+supported_version="1.13.5"
 remote_file_id="2726354765"

--- a/localisation/english/replace/bif_focus_l_english.yml
+++ b/localisation/english/replace/bif_focus_l_english.yml
@@ -861,9 +861,18 @@
  FRA_FRP_party:0 "Front populaire"
  FRA_FRR_party_long:0 "Parti Républicain, Radical et Radical-Socialiste"
  FRA_FRR_party:0 "Parti Radical"
- 
-
-
+ FRA_air1:0 "Air Investments"
+ FRA_air1_desc:0 "Air is the future of war and we must keep up our RnD."
+ FRA_air2:0 "Fighter Aircraft"
+ FRA_air2_desc:0 "We should focus on fighter aircraft."
+ FRA_air3:0 "Bomber Aircraft"
+ FRA_air3_desc:0 "We should focus on long range aircraft."
+ FRA_air4:0 "CAS Emphasis"
+ FRA_air4_desc:0 "In the fast-moving battles of today, the slow artillery pieces on the ground might not be able to keep up. Airplanes carrying bombs can take over their role."
+ FRA_air5:0 "Normandie-Niemen Fighter Regiment"
+ FRA_air5_desc:0 "The Normandie-Niemen flew air missions over the Soviet Union and was the only permanent Western Allied force in the Soviet Union. The Normandie-Niemen was founded in 1942 and fought until the western front was concluded."
+ FRA_air6:0 "Naval Bomber Research"
+ FRA_air6_desc:0 "We need to modernize our naval bomber force to combat any threats at sea."
  FRA_la_front_du_popular:0 "The Political Crisis" 
  FRA_la_front_du_popular_desc:0 "The current political mood in France is one of crisis, politicians are being deposed for any action that makes the public react too heavily. While the people want to contain Germany, they do not actually want France to contain Germany. Meanwhile economic growth is stagnant, and the economy is suffering as a result, the consensus is that something has to be done."
  FRA_public_works:0 "Public Works"

--- a/localisation/english/replace/bif_tooltips_l_english.yml
+++ b/localisation/english/replace/bif_tooltips_l_english.yml
@@ -113,6 +113,7 @@
  air_defense_focus_tt:0 "Set maximum §YAnti-Air§! in §YGreater London Area§!, §YWest Midlands§!, and §YGloucestershire§!"
  air_defense_focus_built_max_tt:0 "Set maximum §YAnti-Air§! in §YGreater London Area§!, §YWest Midlands§!, §YGloucestershire§!, §YSussex§!, §YYorkshire§!, and §YLancashire§!."
  ENG_home_defense_tt:0 "\nSets the §YFort§! and §YCoastal Fort§! to the max level in §YPlymouth§!, §YPortsmouth§!, §YDover§!, §YGreater London Area§!, and §YNorwich§!. Adds 2 levels of §YCoastal Fort§! to all other provinces on the §YEnglish Channel§!. §YSpawns 4 "Home Guard" Infantry Divsions In Britian.§!"
+ less_than_1500_fighter_heavy_tt:0 "Has less than 1500 fighters and heavy fighters deployed or in stockpile"
 
 
 


### PR DESCRIPTION
- Unlocked SAF and MAN designers at game start
- Unlocked JAP naval designers at game start
- CAN and AST given Vauxhall tank and Royal Arsenal artillery orgs. SAF given just Vauxhall tank org
- SOV and FRA given generic CAS designers
- Added Vanilla designer swap to FRA air reorganization
- Added missing FRA focus localization
- Swapped order of JAP agility/range focus and fighter modernization focuses
- JAP agility/range focus funds increased from 1500 to 1600