### PR TITLE
raj nerfs

### DIFF
--- a/common/characters/RAJ.txt
+++ b/common/characters/RAJ.txt
@@ -419,7 +419,7 @@ characters={
 				original_tag  = RAJ
 			}
 			traits = {
-				army_infantry_2
+				army_infantry_1
 			}
 		}
 		portraits={

--- a/common/country_leader/00_traits.txt
+++ b/common/country_leader/00_traits.txt
@@ -135,7 +135,7 @@ leader_traits = {
 		consumer_goods_factor = -0.075
 		neutrality_drift = 0.1
 		stability_weekly = 0.001
-		stability_factor = 0.10
+		stability_factor = 0.05
 
 		ai_will_do = {
 			factor = 1

--- a/common/ideas/british_raj.txt
+++ b/common/ideas/british_raj.txt
@@ -1512,8 +1512,8 @@ ideas = {
 				conscription_factor = -0.08
 				consumer_goods_factor = 0.275
 				autonomy_gain = -0.4
-				stability_factor = -0.15
-				stability_weekly = -0.003
+				stability_factor = -0.20
+				stability_weekly = -0.004
 			}
 		}
 
@@ -1544,8 +1544,8 @@ ideas = {
 				conscription_factor = -0.06
 				consumer_goods_factor = 0.2
 				autonomy_gain = -0.2
-				stability_factor = -0.12
-				stability_weekly = -0.001
+				stability_factor = -0.15
+				stability_weekly = -0.002
 			}
 		}
 
@@ -1571,7 +1571,7 @@ ideas = {
 				conscription_factor = -0.04
 				consumer_goods_factor = 0.15
 				autonomy_gain = -0.1
-				stability_factor = -0.05
+				stability_factor = -0.10
 			}
 		}
 
@@ -1596,6 +1596,7 @@ ideas = {
 			modifier = {
 				consumer_goods_factor = 0.075
 				autonomy_gain = 0.4
+				stability_factor = -0.05
 			}
 		}
 
@@ -1857,8 +1858,8 @@ ideas = {
 				war_support_factor = -0.4
 				surrender_limit = -0.25
 				conscription_factor = -0.15
-				army_core_attack_factor = -0.1
-				army_core_defence_factor = -0.1
+				army_core_attack_factor = -0.20
+				army_core_defence_factor = -0.20
 			}
 		}
 
@@ -1891,8 +1892,8 @@ ideas = {
 				war_support_factor = -0.3
 				surrender_limit = -0.20
 				conscription_factor = -0.1
-				army_core_attack_factor = -0.05
-				army_core_defence_factor = -0.05
+				army_core_attack_factor = -0.1
+				army_core_defence_factor = -0.1
 			}
 		}
 
@@ -1924,7 +1925,8 @@ ideas = {
 				autonomy_gain = 0.5
 				war_support_factor = -0.2
 				surrender_limit = -0.10
-				conscription_factor = -0.05
+				army_core_attack_factor = -0.05
+				army_core_defence_factor = -0.05
 			}
 		}
 

--- a/common/national_focus/india.txt
+++ b/common/national_focus/india.txt
@@ -95,11 +95,8 @@ focus_tree = {
 			add_ideas = RAJ_england_influence
 			ENG = { add_ideas = ENG_foreign_indian_labour_force }
 			add_political_power = 75 
-		    RAJ = { complete_national_focus = RAJ_coastal_defence_fleet }
+		    RAJ = { complete_national_focus = RAJ_bengal_dockyards }
 		    RAJ = { complete_national_focus = RAJ_import_british_design }
-		    RAJ = { complete_national_focus = RAJ_naval_doctrine }
-		    RAJ = { complete_national_focus = RAJ_the_illustrious_class }
-		    RAJ = { complete_national_focus = RAJ_the_princess_royal_class }
 		}
 	}
 	
@@ -1092,7 +1089,7 @@ focus_tree = {
 		x = 14
 		y = 0
 
-		cost = 10
+		cost = 15
 
 		ai_will_do = {
 			factor = 4
@@ -1125,7 +1122,7 @@ focus_tree = {
 		x = 0
 		y = 1
 
-		cost = 10
+		cost = 15
 
 		ai_will_do = {
 			factor = 100
@@ -2826,9 +2823,9 @@ focus_tree = {
    			 
 
 			436 = {
-				add_extra_state_shared_building_slots = 4
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					level = 4
+					level = 2
 					type = industrial_complex
 					instant_build = yes 
 				}
@@ -2934,14 +2931,6 @@ focus_tree = {
 		complete_tooltip = {
 			custom_effect_tooltip = RAJ_attempt_industrialization_tt_3
 			
-			429 = {
-				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					level = 1
-					type = industrial_complex
-					instant_build = yes 
-				}
-			}
 			swap_ideas = {
 				remove_idea = RAJ_agrarian_society
 				add_idea = RAJ_agrarian_society_2 
@@ -2955,14 +2944,6 @@ focus_tree = {
 			add_to_variable = {
 				var = rapid_industrialization
 				value = 7 
-			}
-			429 = {
-				add_extra_state_shared_building_slots = 1
-				add_building_construction = {
-					level = 1
-					type = industrial_complex
-					instant_build = yes 
-				}
 			}
 			swap_ideas = {
 				remove_idea = RAJ_agrarian_society
@@ -5266,7 +5247,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 3
+					level = 2
 					instant_build = yes 
 				}
 			}
@@ -5279,7 +5260,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 3
+					level = 2
 					instant_build = yes 
 				}
 			}
@@ -5315,7 +5296,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 3
+					level = 1
 					instant_build = yes 
 				}
 			}
@@ -5332,7 +5313,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 3
+					level = 1
 					instant_build = yes 
 				}
 			}
@@ -5370,7 +5351,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 3
+					level = 1
 					instant_build = yes 
 				}
 			}
@@ -5387,7 +5368,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 3
+					level = 1
 					instant_build = yes 
 				}
 			}
@@ -5428,7 +5409,7 @@ focus_tree = {
 			
 			add_offsite_building = {
 				type = arms_factory
-				level = 4
+				level = 2
 			}
 		}
 
@@ -5436,7 +5417,7 @@ focus_tree = {
 			
 			add_offsite_building = {
 				type = arms_factory
-				level = 4
+				level = 2
 			}
 		}		
 	}	


### PR DESCRIPTION
Early/Mid game Raj is too powerful. These are changes to reduce the power.

- infantry HC is now specialist (10 > 5% inf bonus atk/def)
- administrative genius stability reduced 10 > 5%
- corruption idea weekly stability increased by 0.1% (early game nerf), as well as stability debuff increased  roughly by 5%
- quit india idea core attack debuffs increased
- focuses to reduce quit india debuffs time increased by 35 days each (70 days in total)
- green path "free" navy focuses reduced/changed
- yellow path civs reduced by 3
- MILs given from military focuses reduced by 7 in total